### PR TITLE
Feature: configurable sync period

### DIFF
--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -3,6 +3,8 @@ import { IPC } from "@shared/ipc";
 import { isLicenseKey, isString } from "@shared/validation";
 import { activateLicense, getLicenseStatus, deleteLicense, applyAutoLaunch } from "../services/settings";
 import { getSetting, saveSetting } from "../services/settings";
+import { applySyncPeriodChange } from "../services/sync";
+import { stopSync } from "../sync-manager";
 import { getGlobalSetting, saveGlobalSetting } from "../services/globalSettings";
 import { loadCredentials } from "../credentials";
 import { dataLog } from "../utils/log";
@@ -17,6 +19,9 @@ function getSettings() {
     autoLaunch: autoLaunchVal !== undefined ? autoLaunchVal : registered,
     launchMinimized: launchMinimizedVal !== undefined ? launchMinimizedVal : registered,
     userName: getSetting("userName") ?? "",
+    historySyncDays: getSetting("historySyncDays") !== undefined
+      ? parseInt(getSetting("historySyncDays")!, 10)
+      : undefined,
   };
 }
 
@@ -66,6 +71,20 @@ export function registerSettingsHandlers(): void {
       if (typeof s.userName !== "string") throw new Error("Invalid userName");
       saveSetting("userName", s.userName);
     }
+
+    if (s.historySyncDays !== undefined) {
+      if (typeof s.historySyncDays !== "number" || s.historySyncDays < 0)
+        throw new Error("Invalid historySyncDays");
+      saveSetting("historySyncDays", String(s.historySyncDays));
+    }
+  });
+
+  ipcMain.handle(IPC.applySyncPeriod, (_event, days: unknown) => {
+    if (typeof days !== "number" || days < 0)
+      throw new Error("Invalid days");
+    stopSync();
+    saveSetting("historySyncDays", String(days));
+    applySyncPeriodChange(days);
   });
 
   // --- Shell ---

--- a/src/main/services/sync.ts
+++ b/src/main/services/sync.ts
@@ -65,7 +65,7 @@ const HISTORICAL_SYNC_DAYS = process.env.HISTORICAL_SYNC_DAYS
 const HISTORICAL_CHUNK_DAYS = 90;
 
 // Production floor: covers all consumer email back to Hotmail/early IMAP era.
-const HISTORICAL_FLOOR_DATE = new Date("1995-01-01");
+const ALL_TIME_FLOOR_DATE = new Date("1995-01-01");
 
 // --- Sync state ---
 
@@ -133,6 +133,37 @@ export function clearSyncDataOnDb(db: Database.Database): void {
 
 export function clearSyncData(): void {
   clearSyncDataOnDb(getDb());
+}
+
+// Applies a sync period change without a full resync:
+// - Extending (more days): resets historical_done so the backfill resumes from the cursor.
+// - Shortening (fewer days): deletes messages older than the new floor and updates the cursor.
+export function applySyncPeriodChange(newDays: number): void {
+  const syncState = getSyncState();
+
+  // Nothing has been synced yet — the new setting will take effect on first sync.
+  if (!syncState.quick_sync_done_at || syncState.historical_cursor === undefined) return;
+
+  const newFloorMs = newDays === 0
+    ? ALL_TIME_FLOOR_DATE.getTime()
+    : Date.now() - newDays * 86_400_000;
+
+  const currentCursor = syncState.historical_cursor;
+
+  if (newFloorMs < currentCursor) {
+    // Extending: new floor is further back — reset done flag so historical sync continues.
+    updateSyncState({ historical_done: 0 });
+    syncLog.info(`Sync period extended: historical sync will resume toward ${new Date(newFloorMs).toISOString().slice(0, 10)}`);
+  } else {
+    // Shortening: delete messages older than the new floor, then recompute stats.
+    const d = getDb();
+    const result = d.prepare("DELETE FROM messages WHERE date < ?").run(newFloorMs) as { changes: number };
+    syncLog.info(`Sync period shortened: removed ${result.changes} messages older than ${new Date(newFloorMs).toISOString().slice(0, 10)}`);
+    recomputeAllVendorFlags();
+    matchVendorCompanies();
+    categorizeVendors();
+    updateSyncState({ historical_cursor: newFloorMs, historical_done: 1 });
+  }
 }
 
 // --- Batch processing ---
@@ -295,9 +326,12 @@ async function runIncrementalSync(
 
   const isFirstRun = !syncState.quick_sync_done_at;
 
-  // First run window: licensed users get 1 year, free users get 30 days.
-  // Subsequent runs use last_sync_at so the window size only matters on first run.
-  const syncDays = licensed ? LICENSED_SYNC_DAYS : FREE_TIER_SYNC_DAYS;
+  // First run window: licensed users use their configured historySyncDays (default 1 year),
+  // free users are capped at FREE_TIER_SYNC_DAYS. Subsequent runs use last_sync_at.
+  const storedDays = getSetting("historySyncDays");
+  const syncDays = licensed
+    ? (storedDays !== undefined ? parseInt(storedDays, 10) : LICENSED_SYNC_DAYS)
+    : FREE_TIER_SYNC_DAYS;
   const since = syncState.last_sync_at
     ? new Date(syncState.last_sync_at)
     : new Date(Date.now() - syncDays * 86_400_000);
@@ -423,10 +457,16 @@ async function runHistoricalChunk(
   let since = new Date(cursor - chunkMs);
   let isLastChunk = false;
 
-  // Determine floor: dev limit via env var, otherwise hard floor of year 2000.
+  // Determine floor: dev limit via env var, then user setting, otherwise all-time floor.
   const floorDate = HISTORICAL_SYNC_DAYS
     ? new Date(Date.now() - HISTORICAL_SYNC_DAYS * 86_400_000)
-    : HISTORICAL_FLOOR_DATE;
+    : (() => {
+        const storedDays = getSetting("historySyncDays");
+        const days = storedDays !== undefined ? parseInt(storedDays, 10) : 365;
+        return days === 0
+          ? ALL_TIME_FLOOR_DATE
+          : new Date(Date.now() - days * 86_400_000);
+      })();
 
   if (since <= floorDate) {
     since = floorDate;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,8 @@ const api: ElectronAPI = {
 
   resyncData: () => ipcRenderer.invoke(IPC.resyncData),
 
+  applySyncPeriod: (days) => ipcRenderer.invoke(IPC.applySyncPeriod, days),
+
   wipeData: () => ipcRenderer.invoke(IPC.wipeData),
 
   openExternal: (url) => ipcRenderer.invoke(IPC.openExternal, url),

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -37,6 +37,8 @@ export default function Settings(): JSX.Element {
     [],
   );
   const [newEntry, setNewEntry] = useState("");
+  const [historySyncDays, setHistorySyncDays] = useState<number>(365);
+  const [pendingHistorySyncDays, setPendingHistorySyncDays] = useState<number | null>(null);
   const [reconnectLoading, setReconnectLoading] = useState(false);
   const [accounts, setAccounts] = useState<AccountSummary[]>([]);
   const [removeAccountEmail, setRemoveAccountEmail] = useState<string | null>(
@@ -59,6 +61,7 @@ export default function Settings(): JSX.Element {
     window.api.getSettings().then((s) => {
       setAutoLaunch(!!s.autoLaunch);
       setLaunchMinimized(!!s.launchMinimized);
+      setHistorySyncDays(s.historySyncDays ?? (license.active ? 365 : 30));
     });
     window.api.getEmailConnection().then(setConnection);
     window.api.listAccounts().then(setAccounts);
@@ -274,6 +277,28 @@ export default function Settings(): JSX.Element {
             ))}
           </div>
 
+          {account && (
+            <div className="flex items-center gap-3 pt-2 border-t border-base-300">
+              <span className="text-sm text-base-content/50 shrink-0">Sync period</span>
+              <select
+                className="select select-bordered select-xs w-36"
+                value={license.active ? historySyncDays : 30}
+                disabled={!license.active}
+                onChange={(e) => setPendingHistorySyncDays(Number(e.target.value))}
+              >
+                <option value={30}>30 days</option>
+                <option value={365}>1 year</option>
+                <option value={730}>2 years</option>
+                <option value={1825}>5 years</option>
+                <option value={3650}>10 years</option>
+                <option value={0}>Full history</option>
+              </select>
+              {!license.active && (
+                <span className="text-xs text-base-content/40">*requires a license</span>
+              )}
+            </div>
+          )}
+
           <div className="flex items-center gap-3 pt-1">
             <button
               className={`btn btn-sm w-fit ${needsLicense ? "btn-ghost" : "btn-primary"}`}
@@ -408,7 +433,15 @@ export default function Settings(): JSX.Element {
                 <span>{account.totalMessages.toLocaleString()}</span>
 
                 <span className="text-base-content/50">Sync period</span>
-                <span>{license.active ? "Full history" : "30 days"}</span>
+                <span>{license.active
+                  ? historySyncDays === 0 ? "Full history"
+                    : historySyncDays === 30 ? "30 days"
+                    : historySyncDays === 365 ? "1 year"
+                    : historySyncDays === 730 ? "2 years"
+                    : historySyncDays === 1825 ? "5 years"
+                    : historySyncDays === 3650 ? "10 years"
+                    : `${historySyncDays} days`
+                  : "30 days"}</span>
               </div>
 
               {(account.providerType === "gmail" ||
@@ -689,6 +722,56 @@ export default function Settings(): JSX.Element {
           </form>
         </dialog>
       )}
+
+      {/* Sync period change confirmation modal */}
+      {pendingHistorySyncDays !== null && (() => {
+        const label = pendingHistorySyncDays === 0 ? "full history"
+          : pendingHistorySyncDays === 30 ? "30 days"
+          : pendingHistorySyncDays === 365 ? "1 year"
+          : pendingHistorySyncDays === 730 ? "2 years"
+          : pendingHistorySyncDays === 1825 ? "5 years"
+          : pendingHistorySyncDays === 3650 ? "10 years"
+          : `${pendingHistorySyncDays} days`;
+        const isExtending = pendingHistorySyncDays === 0 ||
+          (historySyncDays !== 0 && pendingHistorySyncDays > historySyncDays);
+        return (
+          <dialog className="modal modal-open">
+            <div className="modal-box">
+              <h3 className="font-bold text-lg">Change sync period?</h3>
+              <p className="py-4">
+                {isExtending
+                  ? <>Switching to <strong>{label}</strong> will download additional email history in the background. No existing data will be removed.</>
+                  : <>Switching to <strong>{label}</strong> will remove emails older than that from your local database.</>
+                }
+              </p>
+              <div className="modal-action">
+                <button
+                  className="btn btn-ghost"
+                  onClick={() => setPendingHistorySyncDays(null)}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="btn btn-warning"
+                  onClick={async () => {
+                    const days = pendingHistorySyncDays!;
+                    await window.api.applySyncPeriod(days);
+                    setHistorySyncDays(days);
+                    window.api.startSync();
+                    window.api.getAccountInfo().then(setAccount);
+                    setPendingHistorySyncDays(null);
+                  }}
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+            <form method="dialog" className="modal-backdrop">
+              <button onClick={() => setPendingHistorySyncDays(null)}>close</button>
+            </form>
+          </dialog>
+        );
+      })()}
 
       {/* Wipe confirmation modal */}
       {showWipeModal && (

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -36,6 +36,7 @@ export const IPC = {
   getSettings: "get-settings",
   saveSettings: "save-settings",
   resyncData: "resync-data",
+  applySyncPeriod: "settings:apply-sync-period",
   wipeData: "wipe-data",
   noAccountsRemaining: "no-accounts-remaining",
   openExternal: "open-external",
@@ -90,6 +91,7 @@ export interface ElectronAPI {
   getSettings: () => Promise<Settings>;
   saveSettings: (settings: Partial<Settings>) => Promise<void>;
   resyncData: () => Promise<void>;
+  applySyncPeriod: (days: number) => Promise<void>;
   wipeData: () => Promise<void>;
   openExternal: (url: string) => Promise<void>;
   onSyncProgress: (callback: (status: SyncStatus) => void) => () => void;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -252,6 +252,7 @@ export interface Settings {
   autoLaunch?: boolean;
   launchMinimized?: boolean;
   userName?: string;
+  historySyncDays?: number;   // undefined = default 365 days
 }
 
 export interface LicenseStatus {


### PR DESCRIPTION
As soon as I switched to a licensed account, I recognised syncing would not complete.
I let it run back until 2017, which is cool, but in most cases a bit obsolete. It will start to recognize lists that I have long unsubscribed from, but that are still in my inbox/archive. 
Therefore, I think it makes sense to set a standard value for this that is closer to 'now' and make it possible to sync more data if needed.

Opened as draft as I built upon #10 and I think it's better to merge that first (?).

Adds a Sync period dropdown to the Accounts card (below accounts, above Add account). Licensed users default to 1 year, unlicensed are locked to 30 days.

Changing the period shows a confirmation modal and applies changes without a full resync:
- Extending: resets historical_done so backfill resumes from cursor
- Shortening: deletes messages older than new floor, recomputes stats

Any in-progress sync is stopped before applying the change so the new period takes effect immediately on the next sync.

The historySyncDays setting now governs both the incremental first-run window and the historical backfill floor.