### PR TITLE
Add message signal

### DIFF
--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -51,7 +51,7 @@ export function getDb(): Database.Database {
     initSchema(db);
     attachCompaniesDb(db);
     attachBreachesDb(db);
-    const tag = basename(_dbPath, ".db").split("_").pop() ?? "?";
+    const tag = basename(_dbPath!, ".db").split("_").pop() ?? "?";
     dbLog.info(`Database initialized [${tag}]`);
   }
   return db;
@@ -168,7 +168,18 @@ function initSchema(d: Database.Database) {
     );
   `);
 
+  ensureMessageSignalColumn(d);
   d.prepare("INSERT OR IGNORE INTO sync_state (id) VALUES (1)").run();
+}
+
+function ensureMessageSignalColumn(d: Database.Database): void {
+  const cols = d
+    .prepare("PRAGMA table_info(messages)")
+    .all() as Array<{ name: string }>;
+  const hasMessageSignals = cols.some((c) => c.name === "message_signals");
+  if (!hasMessageSignals) {
+    d.exec("ALTER TABLE messages ADD COLUMN message_signals TEXT");
+  }
 }
 
 function attachCompaniesDb(d: Database.Database) {

--- a/src/main/services/messages.ts
+++ b/src/main/services/messages.ts
@@ -1,7 +1,12 @@
 import { getDb } from "../db";
-import type { Message, MessageType, MessageStatus, UnsubscribeEntry } from "@shared/types";
+import type { Message, MessageType, MessageStatus, MessageSignal, UnsubscribeEntry } from "@shared/types";
 import { BODY_PREVIEW_LENGTH } from "@shared/types";
-import { TRANSACTIONAL_PATTERNS, ORDER_PATTERNS } from "@shared/languages";
+import {
+  TRANSACTIONAL_PATTERNS,
+  ORDER_PATTERNS,
+  RESET_PASSWORD_PATTERNS,
+  MFA_CODE_PATTERNS,
+} from "@shared/languages";
 import type { EmailMessage } from "../providers/types";
 import { hasBulkHeaders, matchesAny } from "@shared/utils";
 
@@ -66,17 +71,35 @@ export function classifyMessageType(msg: EmailMessage): MessageType {
   return "personal";
 }
 
+export function detectMessageSignals(msg: EmailMessage): MessageSignal[] {
+  const subject = msg.subject || "";
+  const body = msg.bodyPreview || msg.snippet || "";
+  const text = `${subject} ${body}`;
+  const signals: MessageSignal[] = [];
+
+  if (matchesAny(text, RESET_PASSWORD_PATTERNS)) {
+    signals.push("reset_password");
+  }
+
+  if (matchesAny(text, MFA_CODE_PATTERNS)) {
+    signals.push("mfa_code");
+  }
+
+  return signals;
+}
+
 export function insertMessageVendor(
   msg: EmailMessage,
   vendorId: number,
-  type: MessageType
+  type: MessageType,
+  signals: MessageSignal[] = []
 ) {
   const d = getDb();
   d.prepare(
     `INSERT OR IGNORE INTO messages (
       id, vendor_id, sender_email, sender_name, subject, date, body_preview,
-      raw_headers, type, unsubscribe_url, unsubscribe_method, status, size_bytes
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      raw_headers, type, unsubscribe_url, unsubscribe_method, status, size_bytes, message_signals
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     msg.id,
     vendorId,
@@ -90,7 +113,8 @@ export function insertMessageVendor(
     msg.unsubscribeUrl ?? null,
     msg.unsubscribeMethod ?? "none",
     null,
-    msg.sizeBytes ?? 0
+    msg.sizeBytes ?? 0,
+    signals.length > 0 ? JSON.stringify(signals) : null
   );
 }
 

--- a/src/main/services/sync.ts
+++ b/src/main/services/sync.ts
@@ -12,6 +12,7 @@ import {
 import {
   insertMessageVendor,
   classifyMessageType,
+  detectMessageSignals,
   deleteMessagesByIds,
   getVendorIdsByMessageIds,
 } from "./messages";
@@ -161,7 +162,8 @@ export function processMessagesBatch(messages: EmailMessage[]): void {
     vendorIds.add(vendorId);
 
     const type = classifyMessageType(msg);
-    insertMessageVendor(msg, vendorId, type);
+    const signals = detectMessageSignals(msg);
+    insertMessageVendor(msg, vendorId, type, signals);
   }
 
   for (const vid of vendorIds) {

--- a/src/main/services/vendors.ts
+++ b/src/main/services/vendors.ts
@@ -75,6 +75,22 @@ function parseBreachInfo(vendor: Vendor, row: BreachRow): BreachInfo {
   return { breach, likelyAffected };
 }
 
+const PASSWORD_RESET_DATA_CLASSES = new Set([
+  "passwords",
+  "password hints",
+  "credentials",
+]);
+
+function breachRecommendsPasswordReset(breach: Breach): boolean {
+  const actions = breach.recommendationActions ?? [];
+  if (actions.some((a) => a.toLowerCase().includes("password"))) {
+    return true;
+  }
+  return breach.dataClasses.some((c) =>
+    PASSWORD_RESET_DATA_CLASSES.has(c.toLowerCase())
+  );
+}
+
 // SQL condition: any vendor whose domain appears in the breach database, regardless of first_seen.
 const ON_BREACH_LIST_SQL = `EXISTS (
   SELECT 1 FROM breaches.breaches b
@@ -898,6 +914,34 @@ export function getVendorDetail(groupKey: string): VendorDetail {
     }
   }
 
+  const likelyBreaches = (enrichedVendor.breachInfo ?? [])
+    .filter((bi) => bi.likelyAffected)
+    .sort(
+      (a, b) =>
+        new Date(b.breach.breachDate).getTime() -
+        new Date(a.breach.breachDate).getTime()
+    );
+  const latestLikelyAffectedBreach = likelyBreaches[0];
+  const latestLikelyAffectedBreachAt = latestLikelyAffectedBreach
+    ? new Date(latestLikelyAffectedBreach.breach.breachDate).getTime()
+    : undefined;
+  const latestLikelyAffectedBreachRecommendsPasswordReset = latestLikelyAffectedBreach
+    ? breachRecommendsPasswordReset(latestLikelyAffectedBreach.breach)
+    : undefined;
+
+  const signalRows = d
+    .prepare(
+      `SELECT
+        MAX(CASE WHEN message_signals LIKE '%"reset_password"%' THEN date END) AS latest_reset_password_signal_at,
+        MAX(CASE WHEN message_signals LIKE '%"mfa_code"%' THEN date END) AS latest_mfa_code_signal_at
+       FROM messages
+       WHERE vendor_id = ?`
+    )
+    .get(vendor.id) as {
+      latest_reset_password_signal_at: number | null;
+      latest_mfa_code_signal_at: number | null;
+    };
+
   const activityRows = d
     .prepare(
       `SELECT id, vendor_id, action_type, message_count, size_bytes, actioned_at
@@ -919,5 +963,19 @@ export function getVendorDetail(groupKey: string): VendorDetail {
     actionedAt: r.actioned_at,
   }));
 
-  return { vendor: enrichedVendor, company, senders, bulkMessages, bulkMessageCount, accountMessages, allMessages, activityLog };
+  return {
+    vendor: enrichedVendor,
+    company,
+    senders,
+    bulkMessages,
+    bulkMessageCount,
+    accountMessages,
+    allMessages,
+    activityLog,
+    latestResetPasswordSignalAt:
+      signalRows.latest_reset_password_signal_at ?? undefined,
+    latestMfaCodeSignalAt: signalRows.latest_mfa_code_signal_at ?? undefined,
+    latestLikelyAffectedBreachAt,
+    latestLikelyAffectedBreachRecommendsPasswordReset,
+  };
 }

--- a/src/renderer/pages/AccountDetail.tsx
+++ b/src/renderer/pages/AccountDetail.tsx
@@ -44,6 +44,7 @@ const RISK_BADGE_CLASS: Record<string, string> = {
 
 const TWO_YEARS_MS = 2 * 365.25 * 24 * 60 * 60 * 1000;
 const TEN_YEARS_MS = 10 * 365.25 * 24 * 60 * 60 * 1000;
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
 const LANGUAGES: Record<string, { label: string; flag: string }> = {
   en: { label: "English", flag: "🇬🇧" },
@@ -803,8 +804,30 @@ export default function AccountDetail(): JSX.Element {
 
   // Action item derivation
   const now = Date.now();
+  const ninetyDaysAgo = now - NINETY_DAYS_MS;
   const twoYearsAgo = now - TWO_YEARS_MS;
   const tenYearsAgo = now - TEN_YEARS_MS;
+
+  const latestResetPasswordSignalAt = detail.latestResetPasswordSignalAt;
+  const latestMfaCodeSignalAt = detail.latestMfaCodeSignalAt;
+  const latestLikelyAffectedBreachAt = detail.latestLikelyAffectedBreachAt;
+  const latestBreachRecommendsPasswordReset =
+    !!detail.latestLikelyAffectedBreachRecommendsPasswordReset;
+
+  const shouldRecommendPasswordChange =
+    !!latestLikelyAffectedBreachAt &&
+    latestBreachRecommendsPasswordReset &&
+    (!latestResetPasswordSignalAt ||
+      latestResetPasswordSignalAt < latestLikelyAffectedBreachAt);
+
+  const hasPasswordResetAfterLatestBreach =
+    !!latestLikelyAffectedBreachAt &&
+    latestBreachRecommendsPasswordReset &&
+    !!latestResetPasswordSignalAt &&
+    latestResetPasswordSignalAt >= latestLikelyAffectedBreachAt;
+
+  const hasRecentMfaCodeSignal =
+    !!latestMfaCodeSignalAt && latestMfaCodeSignalAt >= ninetyDaysAgo;
 
   const activeBulkMessages = detail.bulkMessages.filter(
     (m) => m.date > twoYearsAgo && m.status == null
@@ -823,6 +846,9 @@ export default function AccountDetail(): JSX.Element {
 
   const actionItems: string[] = [
     ...(anyLikelyAffected ? ["breachReview", "breachAccess", "breachDeletion"] : []),
+    ...(shouldRecommendPasswordChange ? ["breachPasswordChange"] : []),
+    ...(hasPasswordResetAfterLatestBreach ? ["breachPasswordResetDone"] : []),
+    ...(hasRecentMfaCodeSignal ? ["mfaCodeRecent"] : []),
     ...(hasActiveSubscription ? unsubMethods.map((m) => `unsub-${m.method}`) : []),
     ...(showDeleteMarketing ? ["deleteMarketing"] : []),
     ...(showDeleteAll ? ["deleteAll"] : []),
@@ -852,6 +878,11 @@ export default function AccountDetail(): JSX.Element {
     } else if (id === "breachReview") {
       setBreachOpen(true);
       document.getElementById("breach-alert")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    } else if (id === "breachPasswordChange" || id === "breachPasswordResetDone") {
+      setBreachOpen(true);
+      document.getElementById("breach-alert")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    } else if (id === "mfaCodeRecent") {
+      setActiveTab("emails");
     }
   }
 
@@ -1364,6 +1395,43 @@ export default function AccountDetail(): JSX.Element {
                   anyLoading={actionLoading}
                   actionLabel="Open"
                   onAction={() => handleItemAction("breachDeletion")}
+                />
+              )}
+              {shouldRecommendPasswordChange && (
+                <ActionTaskRow
+                  index={actionItems.indexOf("breachPasswordChange") + 1}
+                  label="Change your password"
+                  description={`The latest likely-affected breach (${latestLikelyAffectedBreachAt ? formatAbsoluteDate(latestLikelyAffectedBreachAt) : "unknown date"}) includes credential risk and no password reset was detected afterwards.`}
+                  done={doneIds.has("breachPasswordChange")}
+                  spinning={false}
+                  anyLoading={actionLoading}
+                  actionLabel="Review"
+                  variant="warning"
+                  onAction={() => handleItemAction("breachPasswordChange")}
+                />
+              )}
+              {hasPasswordResetAfterLatestBreach && (
+                <ActionTaskRow
+                  index={actionItems.indexOf("breachPasswordResetDone") + 1}
+                  label="Password reset detected after breach"
+                  description={`Latest reset email: ${latestResetPasswordSignalAt ? formatAbsoluteDate(latestResetPasswordSignalAt) : "unknown"}. This appears to be after the latest likely-affected breach.`}
+                  done={doneIds.has("breachPasswordResetDone")}
+                  spinning={false}
+                  anyLoading={actionLoading}
+                  actionLabel="Review"
+                  onAction={() => handleItemAction("breachPasswordResetDone")}
+                />
+              )}
+              {hasRecentMfaCodeSignal && (
+                <ActionTaskRow
+                  index={actionItems.indexOf("mfaCodeRecent") + 1}
+                  label="MFA code activity detected"
+                  description={`Latest MFA code email: ${latestMfaCodeSignalAt ? formatAbsoluteDate(latestMfaCodeSignalAt) : "unknown"}. Review recent sign-in activity if this was unexpected.`}
+                  done={doneIds.has("mfaCodeRecent")}
+                  spinning={false}
+                  anyLoading={actionLoading}
+                  actionLabel="Review emails"
+                  onAction={() => handleItemAction("mfaCodeRecent")}
                 />
               )}
               {hasActiveSubscription && unsubMethods.map((entry) => {

--- a/src/shared/languages.ts
+++ b/src/shared/languages.ts
@@ -53,6 +53,51 @@ export const UNSUBSCRIBE_LINK_TEXT: RegExp[] = [
 // Order: order confirmation, receipt, invoice, shipping, billing.
 // Personal (not here): 1:1 human email, colleague — no data at risk.
 
+export const RESET_PASSWORD_PATTERNS: RegExp[] = [
+  // English
+  /\breset your password\b/i,
+  /\bpassword reset\b/i,
+  /\bforgot (your )?password\b/i,
+  /\bchange your password\b/i,
+  // Dutch
+  /\bwachtwoord (opnieuw )?instellen\b/i,
+  /\bwachtwoord wijzigen\b/i,
+  /\bwachtwoord vergeten\b/i,
+  // German
+  /\bpasswort zur[uü]cksetzen\b/i,
+  // French
+  /\br[eé]initialiser (le )?mot de passe\b/i,
+  // Spanish
+  /\brestaurar contraseña\b/i,
+  // Italian
+  /\bresetta (la )?password\b/i,
+  // Portuguese
+  /\bredefinir senha\b/i,
+];
+
+export const MFA_CODE_PATTERNS: RegExp[] = [
+  // English
+  /\bverification code\b/i,
+  /\blogin code\b/i,
+  /\bsecurity code\b/i,
+  /\bone-time (password|code)\b/i,
+  /\b2fa code\b/i,
+  /\bauthentication code\b/i,
+  /\bsign[- ]?in code\b/i,
+  // Dutch
+  /\bverificatiecode\b/i,
+  // German
+  /\bverifizierungscode\b/i,
+  // French
+  /\bcode de v[eé]rification\b/i,
+  // Spanish
+  /\bc[oó]digo de verificaci[oó]n\b/i,
+  // Italian
+  /\bcodice di verifica\b/i,
+  // Portuguese
+  /\bc[oó]digo de verifica[cç][aã]o\b/i,
+];
+
 export const TRANSACTIONAL_PATTERNS: RegExp[] = [
   // English
   /\bwelcome to\b/i,
@@ -61,17 +106,8 @@ export const TRANSACTIONAL_PATTERNS: RegExp[] = [
   /\bconfirm your (email|account)\b/i,
   /\bactivate your account\b/i,
   /\bget started with\b/i,
-  /\breset your password\b/i,
-  /\bpassword reset\b/i,
-  /\bforgot (your )?password\b/i,
-  /\bchange your password\b/i,
-  /\bverification code\b/i,
-  /\blogin code\b/i,
-  /\bsecurity code\b/i,
-  /\bone-time (password|code)\b/i,
-  /\b2fa code\b/i,
-  /\bauthentication code\b/i,
-  /\bsign[- ]?in code\b/i,
+  ...RESET_PASSWORD_PATTERNS,
+  ...MFA_CODE_PATTERNS,
   // English — appointments, bookings, lessons, support
   /\b(appointment|booking|reservation) (confirmation|confirmed|reminder|cancelled|rescheduled)\b/i,
   /\b(lesson|session|class) (cancellation|cancelled|confirmation|confirmed|scheduled|reminder)\b/i,
@@ -82,36 +118,23 @@ export const TRANSACTIONAL_PATTERNS: RegExp[] = [
   /\bafspraak\b/i,
   /\bcontactverzoek\b/i,
   /\bbevestig (je |uw )?e-?mail\b/i,
-  /\bwachtwoord (opnieuw )?instellen\b/i,
-  /\bverificatiecode\b/i,
   /\bwijzig (je |uw )?wachtwoord\b/i,
-  /\bwachtwoord wijzigen\b/i,
-  /\bwachtwoord vergeten\b/i,
   // German
   /\bwillkommen bei\b/i,
   /\be-?mail best[aä]tigen\b/i,
-  /\bpasswort zur[uü]cksetzen\b/i,
-  /\bverifizierungscode\b/i,
   // French
   /\bbienvenue\b/i,
   /\bconfirmez? votre e-?mail\b/i,
-  /\br[eé]initialiser (le )?mot de passe\b/i,
-  /\bcode de v[eé]rification\b/i,
   // Spanish
   /\bbienvenido\b/i,
   /\bconfirma tu e-?mail\b/i,
-  /\brestaurar contraseña\b/i,
-  /\bc[oó]digo de verificaci[oó]n\b/i,
   // Italian
   /\bbenvenuto\b/i,
   /\bconferma la tua e-?mail\b/i,
-  /\bresetta (la )?password\b/i,
-  /\bcodice di verifica\b/i,
   // Portuguese
   /\bbem-vindo\b/i,
   /\bconfirme seu e-?mail\b/i,
-  /\bredefinir senha\b/i,
-  /\bc[oó]digo de verifica[cç][aã]o\b/i,
+  /\bbevestigingscode\b/i,
 ];
 
 export const ORDER_PATTERNS: RegExp[] = [

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,10 @@ export type MessageType =
   | "personal"       // 1:1 conversation
   | "unknown";       // Classification failed — needs improvement
 
+export type MessageSignal =
+  | "reset_password" // Password reset intent detected from mail content
+  | "mfa_code";      // MFA / OTP / verification code intent detected from mail content
+
 export const MESSAGE_TYPES: readonly MessageType[] = ["bulk", "transactional", "order", "personal", "unknown"];
 export function isMessageType(value: unknown): value is MessageType {
   return typeof value === "string" && (MESSAGE_TYPES as readonly string[]).includes(value);
@@ -72,6 +76,8 @@ export interface Breach {
   dataClasses: string[];
   isVerified: boolean;
   isSensitive: boolean;
+  // Optional provider-native recommendations (if available in breach source payload).
+  recommendationActions?: string[];
 }
 
 export interface BreachInfo {
@@ -127,6 +133,8 @@ export interface Message {
   unsubscribe_url?: string;
   unsubscribe_method?: UnsubscribeMethod;
   status?: MessageStatus;
+  // Optional, derived from subject/body classification.
+  signals?: MessageSignal[];
 }
 
 export interface WhitelistEntry {
@@ -228,6 +236,14 @@ export interface VendorDetail {
   first_activity?: number;
   user_email?: string;
   activityLog: ActivityEntry[];
+  // Timestamp of latest message classified with reset_password signal.
+  latestResetPasswordSignalAt?: number;
+  // Timestamp of latest message classified with mfa_code signal.
+  latestMfaCodeSignalAt?: number;
+  // Timestamp of most recent likely-affected breach for this vendor.
+  latestLikelyAffectedBreachAt?: number;
+  // Whether latest likely-affected breach implies password reset recommendation.
+  latestLikelyAffectedBreachRecommendsPasswordReset?: boolean;
 }
 
 // Account / settings


### PR DESCRIPTION
This PR introduces message-level security signals and uses them in account recommendations.
It adds detection for password reset and MFA-code intents from email content, stores those signals per message, and surfaces them in the account detail flow to improve breach-related guidance.

Want to see if this is a certain direction you want to take @wslyvh ?

<img width="669" height="154" alt="change password" src="https://github.com/user-attachments/assets/9b2c97be-a3a7-4c98-99eb-549d963a2cb6" />
