### PR TITLE
prevent crash on fresh install with no active account

### DIFF
--- a/src/main/credentials.ts
+++ b/src/main/credentials.ts
@@ -164,6 +164,7 @@ export function saveCredentials(creds: StoredCredentials, emailOverride?: string
 
 export function loadCredentials(emailOverride?: string): StoredCredentials | undefined {
   if (_preloaded !== undefined) return _preloaded ?? undefined;
+  if (!emailOverride && !_stagingMode && !getActiveEmail()) return undefined;
 
   // Main thread path — use safeStorage
   // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -4,12 +4,13 @@ import { isLicenseKey, isString } from "@shared/validation";
 import { activateLicense, getLicenseStatus, deleteLicense, applyAutoLaunch } from "../services/settings";
 import { getSetting, saveSetting } from "../services/settings";
 import { getGlobalSetting, saveGlobalSetting } from "../services/globalSettings";
-import { loadCredentials } from "../credentials";
+import { loadCredentials, getActiveEmail } from "../credentials";
 import { dataLog } from "../utils/log";
 
 function getSettings() {
-  const creds = loadCredentials();
-  const registered = !!getSetting("registeredAt");
+  const hasAccount = !!getActiveEmail();
+  const creds = hasAccount ? loadCredentials() : undefined;
+  const registered = hasAccount ? !!getSetting("registeredAt") : false;
   const autoLaunchVal = getGlobalSetting("autoLaunch");
   const launchMinimizedVal = getGlobalSetting("launchMinimized");
   const colorTheme = getGlobalSetting("colorTheme");
@@ -17,7 +18,7 @@ function getSettings() {
     providerType: creds?.providerType || "none",
     autoLaunch: autoLaunchVal !== undefined ? autoLaunchVal : registered,
     launchMinimized: launchMinimizedVal !== undefined ? launchMinimizedVal : registered,
-    userName: getSetting("userName") ?? "",
+    userName: hasAccount ? (getSetting("userName") ?? "") : "",
     colorTheme: colorTheme === "silk" ? "silk" : "dim",
   };
 }


### PR DESCRIPTION
fix #38  : prevent crash on fresh install with no active account

loadCredentials() threw "No active account" when called with no
active account set. getSettings() also called getSetting/getDb
unconditionally, which throws "Database not initialized" since
initDb() is only called when an active account exists.

Guard loadCredentials() with an early return, and gate all
credential and DB access in getSettings() behind getActiveEmail().