### PR TITLE
fix: prevent startup crash on fresh installs

### DIFF
--- a/src/main/credentials.ts
+++ b/src/main/credentials.ts
@@ -168,6 +168,7 @@ export function loadCredentials(emailOverride?: string): StoredCredentials | und
   // Main thread path — use safeStorage
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { safeStorage } = require("electron") as typeof import("electron");
+  if (!emailOverride && !_stagingMode && !getActiveEmail()) return undefined;
   const path = getCredentialsPath(emailOverride);
   if (!existsSync(path)) return undefined;
 
@@ -185,6 +186,7 @@ export function loadCredentials(emailOverride?: string): StoredCredentials | und
 }
 
 export function deleteCredentials(emailOverride?: string) {
+  if (!emailOverride && !_stagingMode && !getActiveEmail()) return undefined;
   const path = getCredentialsPath(emailOverride);
   if (existsSync(path)) {
     unlinkSync(path);

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -1,15 +1,16 @@
+import { getActiveEmail, loadCredentials } from "../credentials";
 import { ipcMain, shell } from "electron";
 import { IPC } from "@shared/ipc";
 import { isLicenseKey, isString } from "@shared/validation";
 import { activateLicense, getLicenseStatus, deleteLicense, applyAutoLaunch } from "../services/settings";
 import { getSetting, saveSetting } from "../services/settings";
 import { getGlobalSetting, saveGlobalSetting } from "../services/globalSettings";
-import { loadCredentials } from "../credentials";
 import { dataLog } from "../utils/log";
 
 function getSettings() {
   const creds = loadCredentials();
-  const registered = !!getSetting("registeredAt");
+  const activeEmail = getActiveEmail();
+  const registered = activeEmail ? !!getSetting("registeredAt") : false;
   const autoLaunchVal = getGlobalSetting("autoLaunch");
   const launchMinimizedVal = getGlobalSetting("launchMinimized");
   const colorTheme = getGlobalSetting("colorTheme");
@@ -17,7 +18,7 @@ function getSettings() {
     providerType: creds?.providerType || "none",
     autoLaunch: autoLaunchVal !== undefined ? autoLaunchVal : registered,
     launchMinimized: launchMinimizedVal !== undefined ? launchMinimizedVal : registered,
-    userName: getSetting("userName") ?? "",
+    userName: activeEmail ? (getSetting("userName") ?? "") : "",
     colorTheme: colorTheme === "silk" ? "silk" : "dim",
   };
 }


### PR DESCRIPTION
- Modified loadCredentials and deleteCredentials in src/main/credentials.ts to return early if no account is active.
- Hardened getSettings IPC handler in src/main/handlers/settings.ts to avoid database access when no account is active.