### PR TITLE
feat: responsive mobile nav with hamburger/sidebar

### DIFF
--- a/website/src/components/LayoutSelector.tsx
+++ b/website/src/components/LayoutSelector.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import type { PropsWithChildren } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Github, TwitterIcon } from "lucide-react";
+import { Github, TwitterIcon, Menu, X } from "lucide-react";
 import { NavDropdown } from "@/components/NavDropdown";
 import { Newsletter } from "@/components/Newsletter";
 import { SITE_CONFIG } from "@/utils/config";
@@ -23,6 +24,7 @@ interface LayoutSelectorProps extends PropsWithChildren {
 
 export function LayoutSelector(props: LayoutSelectorProps) {
   const pathname = usePathname();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const standalone = STANDALONE_ROUTES.some(
     (route) => pathname === route || pathname.startsWith(`${route}/`),
   );
@@ -43,7 +45,9 @@ export function LayoutSelector(props: LayoutSelectorProps) {
               <span>🗿</span>
               <span>Paperweight</span>
             </Link>
-            <div className="flex items-center gap-3">
+
+            {/* Desktop nav */}
+            <div className="hidden lg:flex items-center gap-3">
               <NavDropdown
                 label="Resources"
                 href="/resources"
@@ -63,9 +67,121 @@ export function LayoutSelector(props: LayoutSelectorProps) {
                 <Github className="h-4 w-4" />
               </Link>
             </div>
+
+            {/* Mobile header */}
+            <div className="flex lg:hidden items-center gap-2">
+              <a href="/#download" className="btn btn-primary btn-sm">
+                Download
+              </a>
+              <button
+                onClick={() => setMobileMenuOpen(true)}
+                className="btn btn-ghost btn-sm btn-square"
+                aria-label="Open menu"
+              >
+                <Menu className="h-5 w-5" />
+              </button>
+            </div>
           </nav>
         </div>
       </header>
+
+      {/* Mobile sidebar overlay */}
+      {mobileMenuOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-black/50"
+            onClick={() => setMobileMenuOpen(false)}
+          />
+          {/* Sidebar panel */}
+          <div className="fixed right-0 top-0 h-full w-72 bg-base-200 shadow-xl p-6 flex flex-col overflow-y-auto">
+            <div className="flex items-center justify-between mb-6">
+              <span className="text-lg font-bold">Menu</span>
+              <button
+                onClick={() => setMobileMenuOpen(false)}
+                className="btn btn-ghost btn-sm btn-square"
+                aria-label="Close menu"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="flex-1 space-y-6">
+              {/* Resources section */}
+              <div>
+                <Link
+                  href="/resources"
+                  className="font-semibold opacity-60 mb-2 block"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Resources
+                </Link>
+                <ul className="space-y-1 ml-2">
+                  {props.resourceNavLinks.map((item) => (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        className="block py-1.5 hover:opacity-80"
+                        onClick={() => setMobileMenuOpen(false)}
+                      >
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Guides section */}
+              <div>
+                <Link
+                  href="/guides"
+                  className="font-semibold opacity-60 mb-2 block"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Guides
+                </Link>
+                <ul className="space-y-1 ml-2">
+                  {props.guideNavLinks.map((item) => (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        className="block py-1.5 hover:opacity-80"
+                        onClick={() => setMobileMenuOpen(false)}
+                      >
+                        {item.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            {/* Nav footer with socials */}
+            <div className="border-t border-base-300 pt-4 mt-6">
+              <div className="flex items-center gap-4">
+                <Link
+                  href={SITE_CONFIG.GITHUB_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center"
+                  aria-label="GitHub"
+                >
+                  <Github className="h-5 w-5" />
+                </Link>
+                <Link
+                  href={`https://x.com/${SITE_CONFIG.SOCIAL_TWITTER}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center"
+                  aria-label="Twitter"
+                >
+                  <TwitterIcon className="h-5 w-5" />
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       <main className="flex-1">{props.children}</main>
 


### PR DESCRIPTION
## Summary

Fixes the nav being pushed off-screen on mobile by collapsing Resources/Guides dropdowns and the GitHub icon into a hamburger-triggered sidebar drawer. The Download button stays as the primary visible CTA on all screen sizes.

## Changes

**`website/src/components/LayoutSelector.tsx`**
- Wraps desktop nav items in `hidden lg:flex` — unchanged on large screens
- Adds mobile header row (`flex lg:hidden`) with Download CTA + hamburger button
- Implements right-side drawer overlay with:
  - **Resources** section (links to Data Breaches, GDPR Generator, DPAs, Changelog)
  - **Guides** section (dynamic from guide content)
  - **Nav footer** with GitHub and Twitter/X social icons
- Sidebar closes on backdrop click or manual close button
- All nav links in sidebar close the menu on navigation

## How to verify

1. Open the site on a viewport < 1024px (mobile/tablet)
2. Confirm the Download button is visible in the header
3. Tap the hamburger (☰) — sidebar should slide in from the right
4. Verify Resources and Guides sections list their links correctly
5. Tap a link — sidebar closes and navigates
6. Resize to desktop — normal horizontal nav returns