### PR TITLE
warn before deleting all emails and link to cleanup guide

### DIFF
--- a/src/renderer/pages/AccountDetail.tsx
+++ b/src/renderer/pages/AccountDetail.tsx
@@ -36,6 +36,7 @@ import ActionModal from "../components/ActionModal";
 import { CaseListRow } from "../components/CaseListRow";
 import { canAccountSend } from "../utils/account";
 import { errText } from "../utils/errText";
+import { APP_CONFIG } from "@shared/config";
 import {
   ACTION_COLORS,
   activityEntryLabel,
@@ -51,6 +52,7 @@ const RISK_BADGE_CLASS: Record<string, string> = {
 
 const TWO_YEARS_MS = 2 * 365.25 * 24 * 60 * 60 * 1000;
 const TEN_YEARS_MS = 10 * 365.25 * 24 * 60 * 60 * 1000;
+const CLEANUP_GUIDE_URL = `${APP_CONFIG.WEBSITE}/guides/email-cleanup-tools-compared#the-tools`;
 
 function isNoReplyEmail(email: string): boolean {
   const local = email.split("@")[0]?.toLowerCase() ?? "";
@@ -1738,7 +1740,20 @@ export default function AccountDetail(): JSX.Element {
           loading={actionLoading}
         >
           {pendingDelete === "all" ? (
-            <p>Move all <strong>{vendor.message_count}</strong> emails from <strong>{displayName}</strong> to trash? This includes all email types.</p>
+            <>
+              <p>Move all <strong>{vendor.message_count}</strong> emails from <strong>{displayName}</strong> to trash? This includes all email types.</p>
+              <p className="text-xs text-base-content/60">
+                This moves every message to trash, not just marketing mail, and can't be undone from here. If you only want to clear a subset (e.g. old receipts) or want a dedicated cleanup tool, see our{" "}
+                <button
+                  type="button"
+                  className="link link-hover inline"
+                  onClick={() => window.api.openExternal(CLEANUP_GUIDE_URL)}
+                >
+                  email cleanup tools comparison
+                </button>
+                {" "}or use your email provider's own tools instead.
+              </p>
+            </>
           ) : (
             <p>Move marketing emails from <strong>{displayName}</strong> to trash?</p>
           )}

--- a/src/renderer/pages/CaseDetail.tsx
+++ b/src/renderer/pages/CaseDetail.tsx
@@ -15,6 +15,7 @@ import {
 } from "@shared/cases";
 import { detectLanguageFromDomain } from "@shared/gdpr/resolution";
 import { buildReminderEmail, buildFollowupEmail } from "@shared/gdpr/templates";
+import { APP_CONFIG } from "@shared/config";
 import { ArrowLeft, ChevronDown, ExternalLink } from "lucide-react";
 import ActionModal from "../components/ActionModal";
 import { canAccountSend } from "../utils/account";
@@ -27,8 +28,8 @@ import {
 } from "../utils/activityLabels";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const GUIDE_URL = "https://www.paperweight.email/guides/how-to-exercise-your-gdpr-rights";
-const AUTHORITIES_URL = "https://www.paperweight.email/resources/authorities";
+const GUIDE_URL = `${APP_CONFIG.WEBSITE}/guides/how-to-exercise-your-gdpr-rights`;
+const AUTHORITIES_URL = `${APP_CONFIG.WEBSITE}/resources/authorities`;
 
 const NEXT_ACTION_DAY = {
   reminder: REMINDER_AFTER_DAYS,

--- a/website/src/app/guides/[slug]/page.tsx
+++ b/website/src/app/guides/[slug]/page.tsx
@@ -1,10 +1,30 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import dayjs from "dayjs";
-import { marked } from "marked";
+import { Marked, type Tokens } from "marked";
 import { TakeActionCards } from "@/components/TakeActionCards";
 import { GetGuide, GetGuides } from "@/utils/guides";
 import { buildMetadata } from "@/utils/seo";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-");
+}
+
+// Isolated instance (not the shared `marked` singleton) so heading ids for
+// deep-linkable anchors (e.g. #the-tools) don't leak into other pages that
+// render markdown.
+const markdown = new Marked({
+  renderer: {
+    heading({ tokens, depth, text }: Tokens.Heading) {
+      const id = slugify(text);
+      return `<h${depth} id="${id}">${this.parser.parseInline(tokens)}</h${depth}>\n`;
+    },
+  },
+});
 
 export function generateStaticParams() {
   return GetGuides().map((guide) => ({ slug: guide.slug }));
@@ -44,7 +64,7 @@ export default async function Page({
     );
   }
 
-  const bodyHtml = await marked.parse(guide.body);
+  const bodyHtml = await markdown.parse(guide.body);
   const lastUpdated = dayjs(guide.last_updated).format("MMM D, YYYY");
 
   return (


### PR DESCRIPTION
Add confirm modal for `Delete all emails` action with link to the website guides about the clean up tools
<img width="888" height="456" alt="image" src="https://github.com/user-attachments/assets/419296ed-9f0a-4b87-a745-5153c1cc2f53" />


----
Action `Delete all emails` is imo too broad as an action. In most cases I wouldn't use it, and like is mentioned on the website there are other tools better suited for this.

Not sure if I like the dialog because now it feels like `are you sure?`. But the text is too much for a tooltip.