### PR TITLE
fix: run overlap resolution before dedupe in detectPii

### DIFF
--- a/analysis/src/detect/index.ts
+++ b/analysis/src/detect/index.ts
@@ -1,7 +1,13 @@
 // detectPii orchestration: fixed detector sequence,
-// then dedupe by (type, valueNormalized), then overlap resolution (longer
-// span wins, then higher confidence, then detector order), then the
+// then overlap resolution (longer span wins, then higher confidence, then
+// detector order), then dedupe by (type, valueNormalized), then the
 // inQuotedText / inFooter / isOwnIdentifier / selfReference tags.
+// Overlap resolution must run first: the same real-world value (an address
+// printed twice, e.g. invoice + delivery) produces one finding per
+// occurrence, each with its own overlapping rivals at that span (a weaker
+// country guess anchored on the same postcode). Deduping by value first
+// would remove one occurrence's finding before it gets a chance to beat its
+// own rival, letting the weaker rival survive unchallenged.
 import type { Finding, KnownPiiValue } from "../types";
 import { detectAddressBlocks } from "./address";
 import { detectCreditCards } from "./credit-card";
@@ -43,7 +49,7 @@ export function detectPii(text: string, ctx: DetectContext): Finding[] {
     ...detectKnownValues(text, ctx.knownValues ?? []),
   ], ctx.knownValues ?? []);
 
-  const findings = resolveOverlaps(dedupe(raw)).sort((a, b) => a.start - b.start);
+  const findings = dedupe(resolveOverlaps(raw)).sort((a, b) => a.start - b.start);
 
   const own = new Set((ctx.ownEmails ?? []).map((e) => e.toLowerCase()));
   const sender = ctx.senderDomain?.toLowerCase();

--- a/analysis/test/detect.test.ts
+++ b/analysis/test/detect.test.ts
@@ -379,6 +379,29 @@ describe("detectPii orchestration", () => {
     expect(detectPii(text, ctx)).toHaveLength(1);
   });
 
+  it("keeps the city on a repeated address even when the second occurrence's postcode also reads as a bare Belgian anchor", () => {
+    // Same address printed twice (invoice + delivery), compact postcode
+    // first time and spaced the second. The spaced form's bare digits also
+    // satisfy BE's anchor-only postcode pattern, colliding with the correct
+    // NL finding at that span. Deduping the two NL findings (identical
+    // normalized value) before overlap resolution ran used to delete the
+    // second occurrence's NL finding first, leaving the weaker BE match
+    // — which has no city — unchallenged.
+    const text = [
+      "Factuuradres",
+      "Voorbeeldstraat 12",
+      "1234AB Voorbeeldstad",
+      "Afleveradres",
+      "Voorbeeldstraat 12",
+      "1234 AB Voorbeeldstad",
+    ].join("\n");
+    const findings = detectPii(text, ctx);
+    const addresses = findings.filter((f) => f.type === "address");
+    expect(addresses).toHaveLength(1);
+    expect(addresses[0]!.country).toBe("NL");
+    expect(addresses[0]!.valueRaw).toContain("Voorbeeldstad");
+  });
+
   it("flags findings in quoted text", () => {
     const text = "Bedankt!\n\nOp 3 okt 2026 schreef Alex de Vries <alex@voorbeeldmail.example>:\n> Mijn IBAN is NL91 ABNA 0417 1643 00";
     const findings = detectPii(text, { quoted: [{ start: 10, end: text.length }], footer: [] });


### PR DESCRIPTION
A repeated address (e.g. invoice + delivery block, same text) produces one finding per occurrence. Deduping by (type, valueNormalized) first removed a later occurrence's correct NL finding before it could beat its own overlapping rival — a weaker country guess anchored on the same postcode (e.g. a spaced NL postcode's bare digits also matching BE's anchor-only pattern) — leaving that weaker, cityless finding unchallenged in the output.

Swap the order: resolve overlaps per occurrence first, then dedupe by value across the document.