### PR TITLE
detect: recognize PO box / freepost addresses, not just streets

### DIFF
--- a/analysis/src/detect/address.ts
+++ b/analysis/src/detect/address.ts
@@ -1,4 +1,5 @@
-// Address blocks: postcode-anchored only. A street
+// Address blocks: postcode-anchored only. A street (or PO box / freepost
+// reply keyword, which anchors a block the same way without a street name)
 // pattern within ~120 chars of a postcode candidate of the same country
 // emits the whole span as one address finding, extended over a trailing
 // city token when the postcode ends the block. Anchor-only postcodes (bare
@@ -14,9 +15,10 @@ import {
   type PostalCandidate,
 } from "./postal-code";
 
-interface StreetSpec {
+interface AnchorSpec {
   country: string;
   pattern: RegExp;
+  kind: "street" | "box";
 }
 
 // NL/DE house numbers may carry a 1-2 letter suffix ("12 zw", "7 a") — only
@@ -51,38 +53,75 @@ const DE_STREET = new RegExp(
 const FR_STREET =
   /\b\d+(?:\s(?:bis|ter))?,?\s+(?:[Rr]ue|[Aa]venue|[Bb]oulevard|[Pp]lace|[Cc]hemin|[Aa]ll[ée]e|[Ii]mpasse|[Qq]uai|[Cc]ours)\s+(?:(?:de|du|des|la|le)\s+|l'){0,2}[A-ZÀ-Ü][\w'à-ü-]*/g;
 
-const STREETS: StreetSpec[] = [
-  { country: "NL", pattern: NL_STREET },
+// PO box and freepost-reply addresses ("Postbus 2572", "Antwoordnummer 12345")
+// carry no street name — the keyword itself anchors the block, matched
+// case-insensitively since running Dutch prose lowercases it
+// ("postbus 2572, 3500 GN Utrecht").
+const NL_BOX = /\b(?:postbus|antwoordnummer)\s+\d+\b/gi;
+
+// "PO Box 1234" / "P.O. Box 1234" — shared GB/US convention.
+const EN_BOX = /\bP\.?\s?O\.?\s?Box\s+\d+\b/gi;
+
+// "Postfach 1234"
+const DE_BOX = /\bPostfach\s+\d+\b/gi;
+
+// "BP 1234", "B.P. 1234", "Boîte postale 1234"
+const FR_BOX = /\b(?:BP|B\.P\.|Bo[iî]te postale)\s*\d+\b/gi;
+
+// "Apartado 1234", "Apartado de correos 1234", "Apdo. 1234" (ES/PT)
+const IBERIAN_BOX = /\b(?:Apartado(?:\s+de\s+correos)?|Apdo\.?)\s+(?:n[º°]\.?\s*)?\d+\b/gi;
+
+// "Casella Postale 1234", "C.P. 1234"
+const IT_BOX = /\bCasella Postale\s+\d+\b/gi;
+
+const ANCHORS: AnchorSpec[] = [
+  { country: "NL", pattern: NL_STREET, kind: "street" },
+  { country: "NL", pattern: NL_BOX, kind: "box" },
   {
     country: "GB",
+    kind: "street",
     pattern:
       /\b\d+[a-zA-Z]?\s+(?:[A-Z][a-z']+\s+){1,3}(?:Street|Road|Lane|Avenue|Close|Drive|Court|Place|Way|Terrace|Gardens|Crescent|Square|Hill|Row|Walk|Mews)\b/g,
   },
-  { country: "DE", pattern: DE_STREET },
-  { country: "AT", pattern: DE_STREET },
-  { country: "FR", pattern: FR_STREET },
-  { country: "BE", pattern: NL_STREET },
-  { country: "BE", pattern: FR_STREET },
+  { country: "GB", pattern: EN_BOX, kind: "box" },
+  { country: "DE", pattern: DE_STREET, kind: "street" },
+  { country: "DE", pattern: DE_BOX, kind: "box" },
+  { country: "AT", pattern: DE_STREET, kind: "street" },
+  { country: "AT", pattern: DE_BOX, kind: "box" },
+  { country: "FR", pattern: FR_STREET, kind: "street" },
+  { country: "FR", pattern: FR_BOX, kind: "box" },
+  { country: "BE", pattern: NL_STREET, kind: "street" },
+  { country: "BE", pattern: NL_BOX, kind: "box" },
+  { country: "BE", pattern: FR_STREET, kind: "street" },
+  { country: "BE", pattern: FR_BOX, kind: "box" },
   {
     country: "ES",
+    kind: "street",
     pattern:
       /\b(?:Calle|Avenida|Avda\.?|Av\.?|Plaza|Paseo|Camino|C\/)\s*(?:(?:de la|del|de|los|las|la)\s+){0,2}[A-ZÁ-Ú][\w'á-ú-]*(?:\s+[A-ZÁ-Ú][\w'á-ú-]*)?,?\s+(?:n[º°]\s*)?\d+/g,
   },
+  { country: "ES", pattern: IBERIAN_BOX, kind: "box" },
   {
     country: "IT",
+    kind: "street",
     pattern:
       /\b(?:Via|Viale|Piazza|Corso|Vicolo|Largo)\s+(?:(?:della|delle|degli|del|dei|di|San|Santa)\s+){0,2}[A-ZÀ-Ù][\w'à-ù-]*(?:\s+[A-ZÀ-Ù][\w'à-ù-]*)?,?\s+\d+/g,
   },
+  { country: "IT", pattern: IT_BOX, kind: "box" },
   {
     country: "PT",
+    kind: "street",
     pattern:
       /\b(?:Rua|Avenida|Av\.|Pra[çc]a|Travessa|Largo|Estrada)\s+(?:(?:de|do|da|dos|das)\s+){0,2}[A-ZÁ-Ú][\w'á-ú-]*(?:\s+[A-ZÁ-Ú][\w'á-ú-]*)?,?\s+(?:n\.?[º°]?\s*)?\d+/g,
   },
+  { country: "PT", pattern: IBERIAN_BOX, kind: "box" },
   {
     country: "US",
+    kind: "street",
     pattern:
       /\b\d+[A-Za-z]?\s+(?:[A-Z][\w'.-]*\s+){1,3}(?:Street|St|Avenue|Ave|Boulevard|Blvd|Road|Rd|Drive|Dr|Lane|Ln|Court|Ct|Place|Pl|Way|Terrace|Circle|Cir|Parkway|Pkwy|Highway|Hwy)\b\.?/g,
   },
+  { country: "US", pattern: EN_BOX, kind: "box" },
 ];
 
 const MAX_GAP = 60; // chars between street and postcode (~one line)
@@ -100,9 +139,9 @@ export function detectAddressBlocks(text: string, candidates: PostalCandidate[])
   const findings: Finding[] = [];
   for (const pc of candidates) {
     if (pc.tier === "anchor-only" && !CITY.test(text.slice(pc.end))) continue;
-    const specs = STREETS.filter((s) => s.country === pc.country);
+    const specs = ANCHORS.filter((s) => s.country === pc.country);
     const sameCountry = candidates.filter((c) => c.country === pc.country);
-    let best: { start: number; end: number; street: string; gap: number } | undefined;
+    let best: { start: number; end: number; match: string; gap: number; kind: "street" | "box" } | undefined;
     for (const spec of specs) {
       for (const m of text.matchAll(spec.pattern)) {
         const mEnd = m.index + m[0].length;
@@ -128,7 +167,7 @@ export function detectAddressBlocks(text: string, candidates: PostalCandidate[])
           // above the street — is context that anchors the block, not part of
           // the address, and letting it in is what splits one company HQ into
           // several differently-formatted rows.
-          best = { start: m.index, end: Math.max(mEnd, pc.end), street: m[0], gap };
+          best = { start: m.index, end: Math.max(mEnd, pc.end), match: m[0], gap, kind: spec.kind };
         }
       }
     }
@@ -148,7 +187,7 @@ export function detectAddressBlocks(text: string, candidates: PostalCandidate[])
       country: pc.country,
       signals: [
         { id: "anchor.postal-code", detail: pc.value },
-        { id: "pattern.street", detail: best.street },
+        { id: best.kind === "box" ? "pattern.box" : "pattern.street", detail: best.match },
       ],
     });
   }

--- a/analysis/test/detect.test.ts
+++ b/analysis/test/detect.test.ts
@@ -236,6 +236,26 @@ describe("detectAddressBlocks", () => {
     expect(f.signals).toContainEqual({ id: "anchor.postal-code", detail: "1234 AB" });
   });
 
+  it.each([
+    ["NL", "postbus 99, 1234 AB Voorbeeldstad"],
+    ["NL", "Antwoordnummer 99, 1234 AB Voorbeeldstad"],
+    ["GB", "PO Box 99, SW1A 2AA, London"],
+    ["DE", "Postfach 99, 12345 Musterstadt"],
+    ["AT", "Postfach 99, 1010 Wien"],
+    ["FR", "BP 99, 75008 Paris"],
+    ["BE", "BP 99, 2000 Antwerpen"],
+    ["ES", "Apartado de correos 99, 28001 Madrid"],
+    ["IT", "Casella Postale 99, 20121 Milano"],
+    ["PT", "Apartado 99, 1000-100 Lisboa"],
+    ["US", "PO Box 99, Springfield, IL 62704"],
+  ])("matches a %s PO box in place of a street name", (country, text) => {
+    const postal = detectPostalCodes(text);
+    const found = detectAddressBlocks(text, postal.candidates);
+    const f = found.find((x) => x.country === country);
+    expect(f).toBeDefined();
+    expect(f!.signals.some((s) => s.id === "pattern.box")).toBe(true);
+  });
+
   it("matches UK number-first streets", () => {
     const text = "Send to 10 Downing Street, SW1A 2AA, London";
     const postal = detectPostalCodes(text);


### PR DESCRIPTION
Address blocks were postcode-anchored to a street-name pattern only, so a postcode next to "Postbus 2572" or "PO Box 99" never formed an address finding — only the bare postal_code fired.