### PR TITLE
fix: stop address detector merging distinct addresses across countries

### DIFF
--- a/analysis/src/data/postal-codes.ts
+++ b/analysis/src/data/postal-codes.ts
@@ -24,7 +24,9 @@ const US_STATE =
 
 // shared /g patterns are safe: String.matchAll clones the regex
 const BARE_5 = /(?<![\d-])\d{5}(?![\dA-Za-z-])/g; // DE PLZ, FR/ES/IT CP
-const BARE_4 = /(?<![\d-])[1-9]\d{3}(?![\dA-Za-z-])/g; // BE, AT
+// excludes a trailing " XX" (space + 2 uppercase letters): that shape is an
+// NL postcode's own letter pair, not a real BE/AT city name
+const BARE_4 = /(?<![\d-])[1-9]\d{3}(?![\dA-Za-z-])(?! ?[A-Z]{2}(?![A-Za-z]))/g; // BE, AT
 
 export const POSTAL_CODES: PostalSpec[] = [
   // SA/SD/SS are never issued (official rule)

--- a/analysis/src/detect/address.ts
+++ b/analysis/src/detect/address.ts
@@ -113,15 +113,22 @@ export function detectAddressBlocks(text: string, candidates: PostalCandidate[])
         if (sameCountry.some((c) => m.index < c.end && c.start < mEnd)) continue;
         const gap = m.index >= pc.end ? m.index - pc.end : pc.start - mEnd;
         if (gap > MAX_GAP) continue;
-        const between =
-          m.index >= pc.end
-            ? text.slice(pc.end, m.index)
-            : text.slice(mEnd, pc.start);
+        const betweenStart = m.index >= pc.end ? pc.end : mEnd;
+        const betweenEnd = m.index >= pc.end ? m.index : pc.start;
+        const between = text.slice(betweenStart, betweenEnd);
         // A copyright year can satisfy a country's bare numeric postcode
         // pattern, with the company name after it mistaken for a city. A
         // copyright marker between the street and candidate proves they are
         // separate blocks, regardless of the number itself.
         if (COPYRIGHT_BOUNDARY.test(between)) continue;
+        // A whole other postcode of this country sitting between the street
+        // and pc means the street already belongs to that nearer one — pc is
+        // a second, separate address (e.g. a PO box) further down the text.
+        if (
+          sameCountry.some((c) => (
+            c !== pc && c.start >= betweenStart && c.end <= betweenEnd
+          ))
+        ) continue;
         if (!best || gap < best.gap) {
           // The span starts at the street, never before it. Whatever precedes —
           // a year, a label ("adres:"), a person's name, or a postcode written

--- a/analysis/test/detect.test.ts
+++ b/analysis/test/detect.test.ts
@@ -223,6 +223,13 @@ describe("detectPostalCodes", () => {
     expect(candidates.map((c) => c.country).sort()).toEqual(["DE", "ES", "FR", "IT", "US"]);
     expect(candidates.every((c) => c.tier === "anchor-only")).toBe(true);
   });
+
+  it("never reads the digits of an NL postcode as a bare BE/AT code", () => {
+    const { candidates } = detectPostalCodes("Postbus 99, 1234 AB Voorbeeldstad");
+    expect(
+      candidates.some((c) => (c.country === "BE" || c.country === "AT") && c.value === "1234"),
+    ).toBe(false);
+  });
 });
 
 describe("detectAddressBlocks", () => {
@@ -353,6 +360,13 @@ describe("detectAddressBlocks", () => {
     const [f] = detectAddressBlocks(text, postal.candidates);
 
     expect(f!.valueRaw).toBe("Jan van Voorbeeldstraat 12, 1234 XB Voorbeeldstad");
+  });
+
+  it("never crosses one complete postcode+city to pair a street with a farther one", () => {
+    const text = "Voorbeeldstraat 12\n1234 AB Voorbeeldstad Volg ons\nPostbus 99, 5678 CD Anderstad";
+    const postal = detectPostalCodes(text);
+    const found = detectAddressBlocks(text, postal.candidates);
+    expect(found.some((f) => f.valueRaw.includes("Anderstad"))).toBe(false);
   });
 
   it("never joins a street to a copyright year as a Belgian postcode", () => {


### PR DESCRIPTION
BE/AT bare 4-digit postcode pattern matched the digit part of an NL-shaped postcode (e.g. "4800" inside "4800 GC"), tagging the wrong country and letting a street pair with a postcode across an entire separate address block. Exclude the NL letter-suffix shape from the bare-4 pattern, and stop a street from pairing with a postcode when another same-country postcode+city sits between them.