### PR TITLE
fix: enforce add and reconnect account intent

### DIFF
--- a/src/main/handlers/account.ts
+++ b/src/main/handlers/account.ts
@@ -121,9 +121,10 @@ export function registerAccountHandlers(): void {
     return startMicrosoftAuthAndRecordAccount(intent, openInBrowser !== false);
   });
 
-  ipcMain.handle(IPC.saveImapConfig, (_event, config: unknown) => {
+  ipcMain.handle(IPC.saveImapConfig, (_event, intent: unknown, config: unknown) => {
+    if (!isAccountAuthIntent(intent)) throw new Error("Invalid account auth intent");
     if (!isImapConfig(config)) throw new Error("Invalid IMAP config");
-    return saveImapConfigAndRecordAccount(config);
+    return saveImapConfigAndRecordAccount(intent, config);
   });
 
   ipcMain.handle(IPC.updateServerConfig, (_event, server: unknown) => {

--- a/src/main/handlers/account.ts
+++ b/src/main/handlers/account.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { IPC } from "@shared/ipc";
 import { isIntInRange, isString } from "@shared/validation";
 import type { ImapConfig, ServerConfig, SupportInfo, MessageType } from "@shared/types";
-import { isMessageType } from "@shared/types";
+import { isAccountAuthIntent, isMessageType } from "@shared/types";
 import {
   getAccountInfo,
   getConnectionStatus,
@@ -111,11 +111,15 @@ export function registerAccountHandlers(): void {
 
   // openInBrowser defaults to true; the onboarding "copy link" path passes false
   // so the auth URL is copied to the clipboard instead of auto-opened.
-  ipcMain.handle(IPC.startGmailAuth, (_event, openInBrowser: unknown) =>
-    startGmailAuthAndRecordAccount(openInBrowser !== false));
+  ipcMain.handle(IPC.startGmailAuth, (_event, intent: unknown, openInBrowser: unknown) => {
+    if (!isAccountAuthIntent(intent)) throw new Error("Invalid account auth intent");
+    return startGmailAuthAndRecordAccount(intent, openInBrowser !== false);
+  });
 
-  ipcMain.handle(IPC.startMicrosoftAuth, (_event, openInBrowser: unknown) =>
-    startMicrosoftAuthAndRecordAccount(openInBrowser !== false));
+  ipcMain.handle(IPC.startMicrosoftAuth, (_event, intent: unknown, openInBrowser: unknown) => {
+    if (!isAccountAuthIntent(intent)) throw new Error("Invalid account auth intent");
+    return startMicrosoftAuthAndRecordAccount(intent, openInBrowser !== false);
+  });
 
   ipcMain.handle(IPC.saveImapConfig, (_event, config: unknown) => {
     if (!isImapConfig(config)) throw new Error("Invalid IMAP config");

--- a/src/main/services/account.test.ts
+++ b/src/main/services/account.test.ts
@@ -178,7 +178,7 @@ describe("account authentication", () => {
   });
 
   it("rejects an existing IMAP account before testing or persisting it", async () => {
-    const result = await saveImapConfigAndRecordAccount({
+    const result = await saveImapConfigAndRecordAccount({ type: "add" }, {
       host: "imap.example.com",
       port: 993,
       tls: true,
@@ -199,5 +199,42 @@ describe("account authentication", () => {
     expect(mockTestSmtpConnection).not.toHaveBeenCalled();
     expect(mockSaveCredentials).not.toHaveBeenCalled();
     expect(mockRegisterAccount).not.toHaveBeenCalled();
+  });
+
+  it("refreshes IMAP credentials without registering during reconnect", async () => {
+    mockListAccounts.mockReturnValue([{
+      email: "existing@example.com",
+      providerType: "imap",
+      registeredAt: 123,
+    }]);
+    mockGetActiveEmail.mockReturnValue("existing@example.com");
+    const config = {
+      host: "imap.example.com",
+      port: 993,
+      tls: true,
+      username: "existing@example.com",
+      password: "new-app-password",
+      smtp: {
+        host: "smtp.example.com",
+        port: 465,
+        tls: true,
+      },
+    };
+
+    const result = await saveImapConfigAndRecordAccount(
+      { type: "reconnect", email: "existing@example.com" },
+      config,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockTestImapConnection).toHaveBeenCalledWith(config);
+    expect(mockTestSmtpConnection).toHaveBeenCalled();
+    expect(mockSaveCredentials).toHaveBeenCalledWith(
+      { providerType: "imap", imap: config },
+      "existing@example.com",
+    );
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+    expect(mockCreateAccountDb).not.toHaveBeenCalled();
+    expect(mockReconnectDb).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/account.test.ts
+++ b/src/main/services/account.test.ts
@@ -1,0 +1,203 @@
+const mockLoadCredentials = jest.fn();
+const mockSaveCredentials = jest.fn();
+const mockDeleteCredentials = jest.fn();
+const mockSetStagingMode = jest.fn();
+const mockRegisterAccount = jest.fn();
+const mockListAccounts = jest.fn();
+const mockGetActiveEmail = jest.fn();
+const mockStartLoopbackAuth = jest.fn();
+const mockFetchGmailProfileEmail = jest.fn();
+const mockStartMicrosoftLoopbackAuth = jest.fn();
+const mockFetchMicrosoftProfileEmail = jest.fn();
+const mockTestImapConnection = jest.fn();
+const mockTestSmtpConnection = jest.fn();
+const mockCreateAccountDb = jest.fn();
+const mockReconnectDb = jest.fn();
+
+jest.mock("../credentials", () => ({
+  loadCredentials: mockLoadCredentials,
+  saveCredentials: mockSaveCredentials,
+  deleteCredentials: mockDeleteCredentials,
+  hasCredentials: jest.fn(),
+  setStagingMode: mockSetStagingMode,
+  registerAccount: mockRegisterAccount,
+  listAccounts: mockListAccounts,
+  getActiveEmail: mockGetActiveEmail,
+  emailToFileKey: jest.fn(() => "account"),
+  accountTag: jest.fn(() => "tag"),
+}));
+
+jest.mock("../providers/gmail", () => ({
+  startLoopbackAuth: mockStartLoopbackAuth,
+  fetchGmailProfileEmail: mockFetchGmailProfileEmail,
+}));
+
+jest.mock("../providers/microsoft", () => ({
+  startMicrosoftLoopbackAuth: mockStartMicrosoftLoopbackAuth,
+  fetchMicrosoftProfileEmail: mockFetchMicrosoftProfileEmail,
+}));
+
+jest.mock("../providers/imap", () => ({
+  testImapConnection: mockTestImapConnection,
+}));
+jest.mock("../providers/smtp", () => ({
+  testSmtpConnection: mockTestSmtpConnection,
+}));
+jest.mock("../providers/ProviderFactory", () => ({ getProvider: jest.fn() }));
+jest.mock("./settings", () => ({
+  addWhitelistEntry: jest.fn(),
+  getSetting: jest.fn(),
+  saveSetting: jest.fn(),
+  applyAutoLaunch: jest.fn(),
+}));
+jest.mock("./globalSettings", () => ({ saveGlobalSetting: jest.fn() }));
+jest.mock("./stats", () => ({ getDashboardStats: jest.fn() }));
+jest.mock("./sync", () => ({ getSyncState: jest.fn() }));
+jest.mock("./messages", () => ({
+  getMessageIdsByVendor: jest.fn(),
+  deleteVendorMessages: jest.fn(),
+  insertActionLog: jest.fn(),
+}));
+jest.mock("../db", () => ({
+  createAccountDb: mockCreateAccountDb,
+  getDb: jest.fn(),
+  reconnectDb: mockReconnectDb,
+}));
+jest.mock("../utils/log", () => ({
+  authLog: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+  actionLog: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+jest.mock("./profileSeed", () => ({
+  seedProfileEmailsFromCurrentAccount: jest.fn(),
+}));
+
+import {
+  startGmailAuthAndRecordAccount,
+  startMicrosoftAuthAndRecordAccount,
+  saveImapConfigAndRecordAccount,
+} from "./account";
+
+describe("account authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStartLoopbackAuth.mockResolvedValue({ success: true });
+    mockLoadCredentials.mockReturnValue({
+      providerType: "gmail",
+      gmail: { accessToken: "access", refreshToken: "refresh", expiresAt: 123 },
+    });
+    mockFetchGmailProfileEmail.mockResolvedValue("existing@example.com");
+    mockTestImapConnection.mockResolvedValue({ success: true });
+    mockTestSmtpConnection.mockResolvedValue({ success: true });
+    mockListAccounts.mockReturnValue([{
+      email: "existing@example.com",
+      providerType: "gmail",
+      registeredAt: 123,
+    }]);
+    mockGetActiveEmail.mockReturnValue("other@example.com");
+  });
+
+  it("does not persist or register an existing account returned by Add", async () => {
+    const result = await startGmailAuthAndRecordAccount({ type: "add" }, true);
+
+    expect(result).toEqual({
+      success: false,
+      error: "This account is already connected. Use Reconnect instead.",
+    });
+    expect(mockSaveCredentials).not.toHaveBeenCalled();
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+    expect(mockDeleteCredentials).toHaveBeenCalledWith("__staging__");
+  });
+
+  it("updates credentials without registering during an exact reconnect", async () => {
+    mockGetActiveEmail.mockReturnValue("existing@example.com");
+
+    const result = await startGmailAuthAndRecordAccount(
+      { type: "reconnect", email: "existing@example.com" },
+      true,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockSaveCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ providerType: "gmail" }),
+      "existing@example.com",
+    );
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+    expect(mockCreateAccountDb).not.toHaveBeenCalled();
+    expect(mockReconnectDb).not.toHaveBeenCalled();
+    expect(mockDeleteCredentials).toHaveBeenCalledWith("__staging__");
+  });
+
+  it("does not persist or register an existing Microsoft account returned by Add", async () => {
+    mockStartMicrosoftLoopbackAuth.mockResolvedValue({ success: true });
+    mockLoadCredentials.mockReturnValue({
+      providerType: "microsoft",
+      microsoft: { accessToken: "access", refreshToken: "refresh", expiresAt: 123 },
+    });
+    mockFetchMicrosoftProfileEmail.mockResolvedValue("existing@example.com");
+
+    const result = await startMicrosoftAuthAndRecordAccount(
+      { type: "add" },
+      true,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "This account is already connected. Use Reconnect instead.",
+    });
+    expect(mockSaveCredentials).not.toHaveBeenCalled();
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+    expect(mockDeleteCredentials).toHaveBeenCalledWith("__staging__");
+  });
+
+  it("cleans up staging when Gmail auth throws", async () => {
+    mockStartLoopbackAuth.mockRejectedValue(new Error("OAuth crashed"));
+
+    await expect(
+      startGmailAuthAndRecordAccount({ type: "add" }, true),
+    ).rejects.toThrow("OAuth crashed");
+
+    expect(mockSetStagingMode).toHaveBeenNthCalledWith(1, true);
+    expect(mockSetStagingMode).toHaveBeenLastCalledWith(false);
+    expect(mockDeleteCredentials).toHaveBeenCalledWith("__staging__");
+    expect(mockSaveCredentials).not.toHaveBeenCalled();
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+  });
+
+  it("cleans up staging when Microsoft auth throws", async () => {
+    mockStartMicrosoftLoopbackAuth.mockRejectedValue(new Error("OAuth crashed"));
+
+    await expect(
+      startMicrosoftAuthAndRecordAccount({ type: "add" }, true),
+    ).rejects.toThrow("OAuth crashed");
+
+    expect(mockSetStagingMode).toHaveBeenNthCalledWith(1, true);
+    expect(mockSetStagingMode).toHaveBeenLastCalledWith(false);
+    expect(mockDeleteCredentials).toHaveBeenCalledWith("__staging__");
+    expect(mockSaveCredentials).not.toHaveBeenCalled();
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+  });
+
+  it("rejects an existing IMAP account before testing or persisting it", async () => {
+    const result = await saveImapConfigAndRecordAccount({
+      host: "imap.example.com",
+      port: 993,
+      tls: true,
+      username: "existing@example.com",
+      password: "secret",
+      smtp: {
+        host: "smtp.example.com",
+        port: 465,
+        tls: true,
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "This account is already connected. Use Reconnect instead.",
+    });
+    expect(mockTestImapConnection).not.toHaveBeenCalled();
+    expect(mockTestSmtpConnection).not.toHaveBeenCalled();
+    expect(mockSaveCredentials).not.toHaveBeenCalled();
+    expect(mockRegisterAccount).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/account.ts
+++ b/src/main/services/account.ts
@@ -28,10 +28,11 @@ import {
 import { createAccountDb, getDb, reconnectDb } from "../db";
 import { IPC } from "@shared/ipc";
 import { PERSONAL_DOMAINS } from "@paperweight/analysis/contracts";
-import type { ImapConfig, AccountInfo, EmailConnection, MessageType, ServerConfig } from "@shared/types";
+import type { AccountAuthIntent, ImapConfig, AccountInfo, EmailConnection, MessageType, ServerConfig } from "@shared/types";
 import { MARKETING_ACTION_TYPES } from "@shared/types";
 import { authLog, actionLog } from "../utils/log";
 import { seedProfileEmailsFromCurrentAccount } from "./profileSeed";
+import { validateAccountIntent } from "./accountIntent";
 
 // Populate per-account settings in the DB if they are missing.
 // Called after every DB reconnect (account switch or new account setup).
@@ -98,74 +99,115 @@ export function getConnectionStatus() {
   return hasCredentials();
 }
 
-export async function startGmailAuthAndRecordAccount(openInBrowser = true) {
+export async function startGmailAuthAndRecordAccount(
+  intent: AccountAuthIntent,
+  openInBrowser = true,
+) {
   authLog.info("Gmail auth started");
 
-  setStagingMode(true);
-  const result = await startLoopbackAuth(openInBrowser);
-  setStagingMode(false);
+  try {
+    setStagingMode(true);
+    let result;
+    try {
+      result = await startLoopbackAuth(openInBrowser);
+    } finally {
+      setStagingMode(false);
+    }
 
-  if (!result.success) {
-    deleteCredentials("__staging__");
-    authLog.error("Gmail auth failed:", result.error);
+    if (!result.success) {
+      authLog.error("Gmail auth failed:", result.error);
+      return result;
+    }
+
+    const stagingCreds = loadCredentials("__staging__");
+    if (!stagingCreds?.gmail?.accessToken) {
+      return { success: false, error: "Auth failed: no credentials stored" };
+    }
+
+    const email = await fetchGmailProfileEmail(stagingCreds.gmail.accessToken);
+    if (!email) {
+      return { success: false, error: "Auth failed: could not fetch account email" };
+    }
+
+    const intentResult = validateAccountIntent(
+      intent,
+      email,
+      "gmail",
+      listAccounts(),
+      getActiveEmail(),
+    );
+    if (!intentResult.success) return intentResult;
+
+    authLog.info("Gmail auth completed");
+    saveCredentials(stagingCreds, email);
+    if (intent.type === "add") recordAccount(email, "gmail");
+
     return result;
-  }
-
-  const stagingCreds = loadCredentials("__staging__");
-  if (!stagingCreds?.gmail?.accessToken) {
+  } finally {
     deleteCredentials("__staging__");
-    return { success: false, error: "Auth failed: no credentials stored" };
   }
-
-  const email = await fetchGmailProfileEmail(stagingCreds.gmail.accessToken);
-  if (!email) {
-    deleteCredentials("__staging__");
-    return { success: false, error: "Auth failed: could not fetch account email" };
-  }
-
-  authLog.info("Gmail auth completed");
-  saveCredentials(stagingCreds, email);
-  deleteCredentials("__staging__");
-  recordAccount(email, "gmail");
-
-  return result;
 }
 
-export async function startMicrosoftAuthAndRecordAccount(openInBrowser = true) {
+export async function startMicrosoftAuthAndRecordAccount(
+  intent: AccountAuthIntent,
+  openInBrowser = true,
+) {
   authLog.info("Microsoft auth started");
 
-  setStagingMode(true);
-  const result = await startMicrosoftLoopbackAuth(openInBrowser);
-  setStagingMode(false);
+  try {
+    setStagingMode(true);
+    let result;
+    try {
+      result = await startMicrosoftLoopbackAuth(openInBrowser);
+    } finally {
+      setStagingMode(false);
+    }
 
-  if (!result.success) {
-    deleteCredentials("__staging__");
-    authLog.error("Microsoft auth failed:", result.error);
+    if (!result.success) {
+      authLog.error("Microsoft auth failed:", result.error);
+      return result;
+    }
+
+    const stagingCreds = loadCredentials("__staging__");
+    if (!stagingCreds?.microsoft?.accessToken) {
+      return { success: false, error: "Auth failed: no credentials stored" };
+    }
+
+    const email = await fetchMicrosoftProfileEmail(stagingCreds.microsoft.accessToken);
+    if (!email) {
+      return { success: false, error: "Auth failed: could not fetch account email" };
+    }
+
+    const intentResult = validateAccountIntent(
+      intent,
+      email,
+      "microsoft",
+      listAccounts(),
+      getActiveEmail(),
+    );
+    if (!intentResult.success) return intentResult;
+
+    authLog.info("Microsoft auth completed");
+    saveCredentials(stagingCreds, email);
+    if (intent.type === "add") recordAccount(email, "microsoft");
+
     return result;
-  }
-
-  const stagingCreds = loadCredentials("__staging__");
-  if (!stagingCreds?.microsoft?.accessToken) {
+  } finally {
     deleteCredentials("__staging__");
-    return { success: false, error: "Auth failed: no credentials stored" };
   }
-
-  const email = await fetchMicrosoftProfileEmail(stagingCreds.microsoft.accessToken);
-  if (!email) {
-    deleteCredentials("__staging__");
-    return { success: false, error: "Auth failed: could not fetch account email" };
-  }
-
-  authLog.info("Microsoft auth completed");
-  saveCredentials(stagingCreds, email);
-  deleteCredentials("__staging__");
-  recordAccount(email, "microsoft");
-
-  return result;
 }
 
 export async function saveImapConfigAndRecordAccount(config: ImapConfig) {
   try {
+    const intentResult = validateAccountIntent(
+      { type: "add" },
+      config.username,
+      "imap",
+      listAccounts(),
+      getActiveEmail(),
+    );
+    if (!intentResult.success) return intentResult;
+
     authLog.info(
       `Testing IMAP ${config.host}:${config.port} + SMTP ${config.smtp ? `${config.smtp.host}:${config.smtp.port}` : "(not provided)"}`,
     );

--- a/src/main/services/account.ts
+++ b/src/main/services/account.ts
@@ -197,10 +197,13 @@ export async function startMicrosoftAuthAndRecordAccount(
   }
 }
 
-export async function saveImapConfigAndRecordAccount(config: ImapConfig) {
+export async function saveImapConfigAndRecordAccount(
+  intent: AccountAuthIntent,
+  config: ImapConfig,
+) {
   try {
     const intentResult = validateAccountIntent(
-      { type: "add" },
+      intent,
       config.username,
       "imap",
       listAccounts(),
@@ -244,7 +247,7 @@ export async function saveImapConfigAndRecordAccount(config: ImapConfig) {
     const email = config.username;
     authLog.info("IMAP+SMTP config saved");
     saveCredentials({ providerType: "imap", imap: config }, email);
-    recordAccount(email, "imap");
+    if (intent.type === "add") recordAccount(email, "imap");
 
     return { success: true };
   } catch (err) {

--- a/src/main/services/accountIntent.test.ts
+++ b/src/main/services/accountIntent.test.ts
@@ -1,0 +1,112 @@
+import { validateAccountIntent } from "./accountIntent";
+
+describe("account connection intent", () => {
+  it("rejects an add flow that resolves to an existing account", () => {
+    expect(validateAccountIntent(
+      { type: "add" },
+      "Existing@Example.com",
+      "gmail",
+      [{
+        email: "existing@example.com",
+        providerType: "microsoft",
+        registeredAt: 123,
+      }],
+      "other@example.com",
+    )).toEqual({
+      success: false,
+      error: "This account is already connected. Use Reconnect instead.",
+    });
+  });
+
+  it("rejects a reconnect flow that resolves to a different account", () => {
+    expect(validateAccountIntent(
+      { type: "reconnect", email: "existing@example.com" },
+      "other@example.com",
+      "gmail",
+      [{
+        email: "existing@example.com",
+        providerType: "gmail",
+        registeredAt: 123,
+      }],
+      "existing@example.com",
+    )).toEqual({
+      success: false,
+      error: "Sign-in returned a different account. Try again with the account you are reconnecting.",
+    });
+  });
+
+  it("rejects reconnecting an account that is not active", () => {
+    expect(validateAccountIntent(
+      { type: "reconnect", email: "other@example.com" },
+      "other@example.com",
+      "gmail",
+      [{
+        email: "other@example.com",
+        providerType: "gmail",
+        registeredAt: 123,
+      }],
+      "active@example.com",
+    )).toEqual({
+      success: false,
+      error: "The account being reconnected is no longer active. Switch to it and try again.",
+    });
+  });
+
+  it("rejects reconnecting through a different provider", () => {
+    expect(validateAccountIntent(
+      { type: "reconnect", email: "existing@example.com" },
+      "existing@example.com",
+      "gmail",
+      [{
+        email: "existing@example.com",
+        providerType: "microsoft",
+        registeredAt: 123,
+      }],
+      "existing@example.com",
+    )).toEqual({
+      success: false,
+      error: "This account is connected through a different provider.",
+    });
+  });
+
+  it("rejects reconnecting an account that is no longer registered", () => {
+    expect(validateAccountIntent(
+      { type: "reconnect", email: "missing@example.com" },
+      "missing@example.com",
+      "gmail",
+      [],
+      "missing@example.com",
+    )).toEqual({
+      success: false,
+      error: "This account is no longer connected. Add it again instead.",
+    });
+  });
+
+  it("allows adding a new account", () => {
+    expect(validateAccountIntent(
+      { type: "add" },
+      "new@example.com",
+      "gmail",
+      [{
+        email: "existing@example.com",
+        providerType: "gmail",
+        registeredAt: 123,
+      }],
+      "existing@example.com",
+    )).toEqual({ success: true });
+  });
+
+  it("allows reconnecting the active account through its existing provider", () => {
+    expect(validateAccountIntent(
+      { type: "reconnect", email: "Existing@example.com" },
+      "existing@EXAMPLE.COM",
+      "gmail",
+      [{
+        email: "existing@example.com",
+        providerType: "gmail",
+        registeredAt: 123,
+      }],
+      "EXISTING@example.com",
+    )).toEqual({ success: true });
+  });
+});

--- a/src/main/services/accountIntent.ts
+++ b/src/main/services/accountIntent.ts
@@ -1,0 +1,62 @@
+import type { AccountEntry, StoredCredentials } from "../credentials";
+import type { AccountAuthIntent } from "@shared/types";
+
+export type AccountIntentResult =
+  | { success: true }
+  | { success: false; error: string };
+
+function isSameEmail(left: string, right: string): boolean {
+  return left.trim().toLowerCase() === right.trim().toLowerCase();
+}
+
+export function validateAccountIntent(
+  intent: AccountAuthIntent,
+  resolvedEmail: string,
+  providerType: StoredCredentials["providerType"],
+  accounts: AccountEntry[],
+  activeEmail?: string,
+): AccountIntentResult {
+  if (
+    intent.type === "add"
+    && accounts.some((account) => isSameEmail(account.email, resolvedEmail))
+  ) {
+    return {
+      success: false,
+      error: "This account is already connected. Use Reconnect instead.",
+    };
+  }
+  if (
+    intent.type === "reconnect"
+    && !isSameEmail(intent.email, resolvedEmail)
+  ) {
+    return {
+      success: false,
+      error: "Sign-in returned a different account. Try again with the account you are reconnecting.",
+    };
+  }
+  if (
+    intent.type === "reconnect"
+    && (!activeEmail || !isSameEmail(intent.email, activeEmail))
+  ) {
+    return {
+      success: false,
+      error: "The account being reconnected is no longer active. Switch to it and try again.",
+    };
+  }
+  const reconnectAccount = intent.type === "reconnect"
+    ? accounts.find((account) => isSameEmail(account.email, intent.email))
+    : undefined;
+  if (intent.type === "reconnect" && !reconnectAccount) {
+    return {
+      success: false,
+      error: "This account is no longer connected. Add it again instead.",
+    };
+  }
+  if (reconnectAccount && reconnectAccount.providerType !== providerType) {
+    return {
+      success: false,
+      error: "This account is connected through a different provider.",
+    };
+  }
+  return { success: true };
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,11 +9,11 @@ const api: ElectronAPI = {
 
   getConnectionStatus: () => ipcRenderer.invoke(IPC.getConnectionStatus),
 
-  startGmailAuth: (openInBrowser) =>
-    ipcRenderer.invoke(IPC.startGmailAuth, openInBrowser),
+  startGmailAuth: (intent, openInBrowser) =>
+    ipcRenderer.invoke(IPC.startGmailAuth, intent, openInBrowser),
 
-  startMicrosoftAuth: (openInBrowser) =>
-    ipcRenderer.invoke(IPC.startMicrosoftAuth, openInBrowser),
+  startMicrosoftAuth: (intent, openInBrowser) =>
+    ipcRenderer.invoke(IPC.startMicrosoftAuth, intent, openInBrowser),
 
   saveImapConfig: (config) => ipcRenderer.invoke(IPC.saveImapConfig, config),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,7 +15,8 @@ const api: ElectronAPI = {
   startMicrosoftAuth: (intent, openInBrowser) =>
     ipcRenderer.invoke(IPC.startMicrosoftAuth, intent, openInBrowser),
 
-  saveImapConfig: (config) => ipcRenderer.invoke(IPC.saveImapConfig, config),
+  saveImapConfig: (intent, config) =>
+    ipcRenderer.invoke(IPC.saveImapConfig, intent, config),
 
   updateServerConfig: (server) =>
     ipcRenderer.invoke(IPC.updateServerConfig, server),

--- a/src/renderer/components/ProviderConnect.tsx
+++ b/src/renderer/components/ProviderConnect.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { CheckCircle2, Check, Copy, Mail } from "lucide-react";
 import { findPresetById, PROVIDER_PRESETS } from "@shared/email-providers";
 import type { ProviderPreset } from "@shared/email-providers";
+import type { AccountAuthIntent } from "@shared/types";
 import {
   AppleLogo,
   GoogleLogo,
@@ -278,10 +279,12 @@ function OAuthConnect({
 // ── Gmail Connect ─────────────────────────────────────────────────────────────
 
 export function GmailConnect({
+  intent,
   onSuccess,
   onBack,
   copyFirst = false,
 }: {
+  intent: AccountAuthIntent;
   onSuccess: () => void;
   onBack: () => void;
   copyFirst?: boolean;
@@ -289,7 +292,7 @@ export function GmailConnect({
   return (
     <OAuthConnect
       providerName="Google"
-      startAuth={(open) => window.api.startGmailAuth(open)}
+      startAuth={(open) => window.api.startGmailAuth(intent, open)}
       copyFirst={copyFirst}
       onSuccess={onSuccess}
       onBack={onBack}
@@ -300,10 +303,12 @@ export function GmailConnect({
 // ── Microsoft Connect ─────────────────────────────────────────────────────────
 
 export function MicrosoftConnect({
+  intent,
   onSuccess,
   onBack,
   copyFirst = false,
 }: {
+  intent: AccountAuthIntent;
   onSuccess: () => void;
   onBack: () => void;
   copyFirst?: boolean;
@@ -311,7 +316,7 @@ export function MicrosoftConnect({
   return (
     <OAuthConnect
       providerName="Microsoft"
-      startAuth={(open) => window.api.startMicrosoftAuth(open)}
+      startAuth={(open) => window.api.startMicrosoftAuth(intent, open)}
       copyFirst={copyFirst}
       onSuccess={onSuccess}
       onBack={onBack}

--- a/src/renderer/components/ProviderConnect.tsx
+++ b/src/renderer/components/ProviderConnect.tsx
@@ -408,7 +408,7 @@ export function AppleConnect({
     setLoading(true);
     setError("");
 
-    const result = await window.api.saveImapConfig({
+    const result = await window.api.saveImapConfig({ type: "add" }, {
       host,
       port,
       tls,
@@ -562,7 +562,7 @@ export function ProtonConnect({
     setLoading(true);
     setError("");
 
-    const result = await window.api.saveImapConfig({
+    const result = await window.api.saveImapConfig({ type: "add" }, {
       host,
       port,
       tls,
@@ -759,7 +759,7 @@ export function ImapConnect({
     setLoading(true);
     setError("");
 
-    const result = await window.api.saveImapConfig({
+    const result = await window.api.saveImapConfig({ type: "add" }, {
       host,
       port,
       tls,

--- a/src/renderer/components/ServerSettingsModal.tsx
+++ b/src/renderer/components/ServerSettingsModal.tsx
@@ -22,6 +22,7 @@ export default function ServerSettingsModal({
   const [smtpHost, setSmtpHost] = useState(initial.smtp?.host ?? "");
   const [smtpPort, setSmtpPort] = useState(initial.smtp?.port ?? 465);
   const [smtpTls, setSmtpTls] = useState(initial.smtp?.tls ?? true);
+  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -30,16 +31,34 @@ export default function ServerSettingsModal({
     setLoading(true);
     setError("");
 
-    const result = await window.api.updateServerConfig({
-      imap: { host, port, tls, allowSelfSigned },
-      smtp: { host: smtpHost, port: smtpPort, tls: smtpTls },
-    });
-    setLoading(false);
+    try {
+      const result = password.trim()
+        ? await window.api.saveImapConfig(
+            { type: "reconnect", email },
+            {
+              host,
+              port,
+              tls,
+              allowSelfSigned,
+              username: email,
+              password,
+              smtp: { host: smtpHost, port: smtpPort, tls: smtpTls },
+            },
+          )
+        : await window.api.updateServerConfig({
+            imap: { host, port, tls, allowSelfSigned },
+            smtp: { host: smtpHost, port: smtpPort, tls: smtpTls },
+          });
 
-    if (result.success) {
-      onSaved();
-    } else {
-      setError(result.error || "Failed to update server settings");
+      if (result.success) {
+        onSaved();
+      } else {
+        setError(result.error || "Failed to update server settings");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update server settings");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -79,6 +98,20 @@ export default function ServerSettingsModal({
             onPort={setSmtpPort}
             onTls={setSmtpTls}
           />
+
+          <label className="form-control">
+            <span className="label-text text-xs font-medium text-base-content/60 uppercase tracking-wide mb-1.5">
+              New password
+            </span>
+            <input
+              type="password"
+              className="input input-bordered input-sm"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Leave blank to keep current password"
+              autoComplete="new-password"
+            />
+          </label>
 
           {error && (
             <div className="alert alert-error text-sm">

--- a/src/renderer/components/SyncStatusBar.test.ts
+++ b/src/renderer/components/SyncStatusBar.test.ts
@@ -1,0 +1,15 @@
+import { isOAuthTokenError } from "./syncStatus";
+
+describe("SyncStatusBar OAuth recovery", () => {
+  it("recognizes normalized authorization-expired errors", () => {
+    expect(
+      isOAuthTokenError(
+        "Authorization expired. Reconnect your account to continue syncing.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not offer OAuth reconnect for unrelated sync errors", () => {
+    expect(isOAuthTokenError("Could not reach the mail server.")).toBe(false);
+  });
+});

--- a/src/renderer/components/SyncStatusBar.tsx
+++ b/src/renderer/components/SyncStatusBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { SyncStatus } from "@shared/types";
+import { isOAuthTokenError } from "./syncStatus";
 
 function formatMonthYear(ts: number): string {
   return new Date(ts).toLocaleDateString("en-US", { month: "short", year: "numeric" });
@@ -14,14 +15,6 @@ function formatRelativeTime(ts: number): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
-}
-
-function isGmailTokenError(error?: string): boolean {
-  return !!(
-    error &&
-    (error.includes("Gmail authorization expired") ||
-      error.includes("Failed to refresh access token"))
-  );
 }
 
 export default function SyncStatusBar(): JSX.Element {
@@ -53,7 +46,22 @@ export default function SyncStatusBar(): JSX.Element {
   const handleReconnect = async () => {
     setReconnecting(true);
     try {
-      const result = await window.api.startGmailAuth();
+      const account = await window.api.getAccountInfo();
+      const intent = {
+        type: "reconnect",
+        email: account.email,
+      } as const;
+      let result: { success: boolean; error?: string };
+      if (account.providerType === "microsoft") {
+        result = await window.api.startMicrosoftAuth(intent);
+      } else if (account.providerType === "gmail") {
+        result = await window.api.startGmailAuth(intent);
+      } else {
+        result = {
+          success: false,
+          error: "Reconnect is only available for Gmail and Microsoft accounts",
+        };
+      }
       if (result.success) {
         window.api.startSync();
       } else {
@@ -64,7 +72,7 @@ export default function SyncStatusBar(): JSX.Element {
     }
   };
 
-  const showReconnect = isGmailTokenError(status.error);
+  const showReconnect = isOAuthTokenError(status.error);
   const analyzingMessages =
     status.running && status.message === "Analyzing messages";
 

--- a/src/renderer/components/syncStatus.ts
+++ b/src/renderer/components/syncStatus.ts
@@ -1,0 +1,8 @@
+export function isOAuthTokenError(error?: string): boolean {
+  return !!(
+    error &&
+    (error.includes("Gmail authorization expired") ||
+      error.includes("Failed to refresh access token") ||
+      error.includes("Authorization expired. Reconnect your account"))
+  );
+}

--- a/src/renderer/pages/Onboarding.tsx
+++ b/src/renderer/pages/Onboarding.tsx
@@ -142,6 +142,7 @@ export default function Onboarding(): JSX.Element {
           )}
           {view === "gmail" && (
             <GmailConnect
+              intent={{ type: "add" }}
               copyFirst={copyFirst}
               onSuccess={handleSuccess}
               onBack={() => setView("select")}
@@ -149,6 +150,7 @@ export default function Onboarding(): JSX.Element {
           )}
           {view === "microsoft" && (
             <MicrosoftConnect
+              intent={{ type: "add" }}
               copyFirst={copyFirst}
               onSuccess={handleSuccess}
               onBack={() => setView("select")}

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -26,6 +26,7 @@ import {
   setColorTheme as applyAndSaveColorTheme,
   type ColorTheme,
 } from "../utils/colorTheme";
+import { reconnectError } from "./settingsReconnect";
 
 type AddAccountView = "provider" | "gmail" | "microsoft" | "apple" | "proton" | "imap";
 
@@ -52,6 +53,7 @@ export default function Settings(): JSX.Element {
   );
   const [newEntry, setNewEntry] = useState("");
   const [reconnectLoading, setReconnectLoading] = useState(false);
+  const [reconnectFailure, setReconnectFailure] = useState("");
   const { accounts, refresh: refreshAccounts } = useAccounts();
   const [removeAccountEmail, setRemoveAccountEmail] = useState<string | null>(
     null,
@@ -211,6 +213,11 @@ export default function Settings(): JSX.Element {
 
   const handleReconnect = async (): Promise<void> => {
     if (!account) return;
+    setReconnectFailure("");
+    if (account.providerType === "imap") {
+      setShowServerSettings(true);
+      return;
+    }
     setReconnectLoading(true);
     try {
       let result: { success: boolean; error?: string };
@@ -219,18 +226,25 @@ export default function Settings(): JSX.Element {
           type: "reconnect",
           email: account.email,
         });
-      } else {
+      } else if (account.providerType === "gmail") {
         result = await window.api.startGmailAuth({
           type: "reconnect",
           email: account.email,
         });
+      } else {
+        result = { success: false, error: "Reconnect is not available for this account" };
       }
-      if (result.success) {
-        const conn = await window.api.getEmailConnection();
-        setConnection(conn);
-        setAccount(await window.api.getAccountInfo());
-        window.api.startSync();
+      const error = reconnectError(result);
+      if (error) {
+        setReconnectFailure(error);
+        return;
       }
+      const conn = await window.api.getEmailConnection();
+      setConnection(conn);
+      setAccount(await window.api.getAccountInfo());
+      window.api.startSync();
+    } catch (err) {
+      setReconnectFailure(err instanceof Error ? err.message : "Reconnect failed");
     } finally {
       setReconnectLoading(false);
     }
@@ -493,7 +507,8 @@ export default function Settings(): JSX.Element {
               </div>
 
               {(account.providerType === "gmail" ||
-                account.providerType === "microsoft") && (
+                account.providerType === "microsoft" ||
+                account.providerType === "imap") && (
                   <button
                     className="btn btn-sm btn-primary w-fit"
                     onClick={handleReconnect}
@@ -506,6 +521,9 @@ export default function Settings(): JSX.Element {
                     )}
                   </button>
                 )}
+              {reconnectFailure && (
+                <p className="text-sm text-error">{reconnectFailure}</p>
+              )}
             </>
           )}
         </div>
@@ -752,7 +770,9 @@ export default function Settings(): JSX.Element {
           onClose={() => setShowServerSettings(false)}
           onSaved={() => {
             setShowServerSettings(false);
+            setReconnectFailure("");
             window.api.getAccountInfo().then(setAccount);
+            window.api.getEmailConnection().then(setConnection);
           }}
         />
       )}

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -773,6 +773,7 @@ export default function Settings(): JSX.Element {
             setReconnectFailure("");
             window.api.getAccountInfo().then(setAccount);
             window.api.getEmailConnection().then(setConnection);
+            window.api.startSync();
           }}
         />
       )}

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -210,13 +210,20 @@ export default function Settings(): JSX.Element {
   const connectionHealthy = !!connection;
 
   const handleReconnect = async (): Promise<void> => {
+    if (!account) return;
     setReconnectLoading(true);
     try {
       let result: { success: boolean; error?: string };
-      if (account?.providerType === "microsoft") {
-        result = await window.api.startMicrosoftAuth();
+      if (account.providerType === "microsoft") {
+        result = await window.api.startMicrosoftAuth({
+          type: "reconnect",
+          email: account.email,
+        });
       } else {
-        result = await window.api.startGmailAuth();
+        result = await window.api.startGmailAuth({
+          type: "reconnect",
+          email: account.email,
+        });
       }
       if (result.success) {
         const conn = await window.api.getEmailConnection();
@@ -661,6 +668,7 @@ export default function Settings(): JSX.Element {
 
             {addAccountView === "gmail" && (
               <GmailConnect
+                intent={{ type: "add" }}
                 copyFirst={addAccountCopyFirst}
                 onSuccess={handleAddAccountSuccess}
                 onBack={() => setAddAccountView("provider")}
@@ -669,6 +677,7 @@ export default function Settings(): JSX.Element {
 
             {addAccountView === "microsoft" && (
               <MicrosoftConnect
+                intent={{ type: "add" }}
                 copyFirst={addAccountCopyFirst}
                 onSuccess={handleAddAccountSuccess}
                 onBack={() => setAddAccountView("provider")}

--- a/src/renderer/pages/settingsReconnect.test.ts
+++ b/src/renderer/pages/settingsReconnect.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { reconnectError } from "./settingsReconnect";
 
 describe("Settings reconnect result", () => {
@@ -16,5 +18,15 @@ describe("Settings reconnect result", () => {
 
   it("returns no error after a successful reconnect", () => {
     expect(reconnectError({ success: true })).toBeUndefined();
+  });
+
+  it("starts sync after IMAP server settings are saved", () => {
+    const source = readFileSync(join(__dirname, "Settings.tsx"), "utf8");
+    const modal = source.slice(
+      source.indexOf("{/* Server settings modal (IMAP accounts only) */}"),
+      source.indexOf("{/* Remove account confirmation modal */}"),
+    );
+
+    expect(modal).toContain("window.api.startSync();");
   });
 });

--- a/src/renderer/pages/settingsReconnect.test.ts
+++ b/src/renderer/pages/settingsReconnect.test.ts
@@ -1,0 +1,20 @@
+import { reconnectError } from "./settingsReconnect";
+
+describe("Settings reconnect result", () => {
+  it("returns the service error for a rejected reconnect", () => {
+    expect(
+      reconnectError({
+        success: false,
+        error: "Sign-in returned a different account.",
+      }),
+    ).toBe("Sign-in returned a different account.");
+  });
+
+  it("returns a fallback when a rejected reconnect has no error", () => {
+    expect(reconnectError({ success: false })).toBe("Reconnect failed");
+  });
+
+  it("returns no error after a successful reconnect", () => {
+    expect(reconnectError({ success: true })).toBeUndefined();
+  });
+});

--- a/src/renderer/pages/settingsReconnect.ts
+++ b/src/renderer/pages/settingsReconnect.ts
@@ -1,0 +1,8 @@
+interface ReconnectResult {
+  success: boolean;
+  error?: string;
+}
+
+export function reconnectError(result: ReconnectResult): string | undefined {
+  return result.success ? undefined : result.error || "Reconnect failed";
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -137,7 +137,8 @@ export interface ElectronAPI {
     openInBrowser?: boolean,
   ) => Promise<{ success: boolean; error?: string }>;
   saveImapConfig: (
-    config: ImapConfig
+    intent: AccountAuthIntent,
+    config: ImapConfig,
   ) => Promise<{ success: boolean; error?: string }>;
   updateServerConfig: (
     server: ServerConfig & { smtp: NonNullable<ServerConfig["smtp"]> },

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountAuthIntent,
   AccountInfo,
   AccountSummary,
   ActionType,
@@ -127,8 +128,14 @@ export interface UpdateInfo {
 export interface ElectronAPI {
   getLastUpdateInfo: () => Promise<UpdateInfo | null>;
   getConnectionStatus: () => Promise<boolean>;
-  startGmailAuth: (openInBrowser?: boolean) => Promise<{ success: boolean; error?: string }>;
-  startMicrosoftAuth: (openInBrowser?: boolean) => Promise<{ success: boolean; error?: string }>;
+  startGmailAuth: (
+    intent: AccountAuthIntent,
+    openInBrowser?: boolean,
+  ) => Promise<{ success: boolean; error?: string }>;
+  startMicrosoftAuth: (
+    intent: AccountAuthIntent,
+    openInBrowser?: boolean,
+  ) => Promise<{ success: boolean; error?: string }>;
   saveImapConfig: (
     config: ImapConfig
   ) => Promise<{ success: boolean; error?: string }>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -457,6 +457,19 @@ export interface VendorDetail {
 
 // Account / settings
 
+export type AccountAuthIntent =
+  | { type: "add" }
+  | { type: "reconnect"; email: string };
+
+export function isAccountAuthIntent(value: unknown): value is AccountAuthIntent {
+  if (!value || typeof value !== "object") return false;
+  const intent = value as Record<string, unknown>;
+  if (intent.type === "add") return true;
+  return intent.type === "reconnect"
+    && typeof intent.email === "string"
+    && intent.email.trim() !== "";
+}
+
 export interface AccountSummary {
   email: string;
   providerType: string;


### PR DESCRIPTION
## Summary

- pass explicit Add or Reconnect intent through renderer, preload, IPC, and account services
- reject duplicate Add and mismatched Reconnect flows before permanent credential or account-state changes
- keep OAuth reconnect limited to credential refreshes and guarantee staging cleanup
- let IMAP, Apple, and Proton users replace passwords without removing their account or local database
- surface reconnect failures in Settings, including wrong-account OAuth results
- add regression coverage for Gmail, Microsoft, IMAP, and reconnect error handling

## Verification

- `npx --yes jest src/main/services/account.test.ts src/main/services/accountIntent.test.ts src/renderer/components/SyncStatusBar.test.ts src/renderer/pages/settingsReconnect.test.ts --runInBand` — 20 passed
- `npx --yes yarn@1.22.22 typecheck` — passed
- `npx --yes yarn@1.22.22 test:analysis` — 276 passed
- `npx --no-install electron-vite build` — passed

Closes #17
