### PR TITLE
Match profile dates of birth in analysis

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -76,11 +76,14 @@ own storage, aggregation across documents, suppression policy, masking,
 scheduling, and any product claim about ownership or retention.
 
 Consumers may supply already-normalized `knownValues` for the existing finding
-types. The engine finds exact occurrences under that type's normal formatting
-rules and emits `known-value.exact` evidence when a generic detector did not
-already produce the same value. This is detector input, not an ownership claim:
-it does not infer a country, add names or dates of birth, or promote confidence
-to `verified`. Ownership remains consumer policy.
+types. For `date_of_birth`, scanning is activated only by a complete canonical
+known DOB (`YYYY-MM-DD`). Complete date candidates are calendar-validated and
+normalized; only exact equivalents emit `known-value.exact`. The engine does
+not perform generic date detection or claim profile ownership. For other known
+types, it finds exact occurrences under that type's normal formatting rules
+and emits `known-value.exact` evidence when a generic detector did not already
+produce the same value. This is detector input, not an ownership claim:
+consumers own the policy for deciding whose value it is.
 
 A structured address may additionally carry normalized street, house-number,
 and postcode components. The engine requires the exact street phrase adjacent
@@ -101,6 +104,7 @@ verification wherever a checksum exists:
 | `iban`        | country length table + ISO 7064 mod-97                        | `verified`               |
 | `credit_card` | IIN prefix + scheme length + Luhn; masked forms separately    | `verified` / `contextual`|
 | `phone`       | libphonenumber-js; region from locale option or sender ccTLD  | `verified` / `contextual`|
+| `date_of_birth` | complete known DOB; calendar-valid candidate normalized     | `pattern`                |
 | `national_id` | per-country registry: official checksum, optional context word| `verified` / `contextual`|
 | `postal_code` | per-country registry; only distinctive formats stand alone    | `pattern`                |
 | `address`     | postcode-anchored street grammar                              | `contextual`             |

--- a/analysis/package.json
+++ b/analysis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperweight/analysis",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Local, deterministic message analysis engine",
   "license": "MIT",

--- a/analysis/src/contracts.ts
+++ b/analysis/src/contracts.ts
@@ -34,6 +34,7 @@ export const FINDING_TYPES = [
   "phone",
   "postal_code",
   "address",
+  "date_of_birth",
 ] as const;
 
 export type FindingType = (typeof FINDING_TYPES)[number];
@@ -48,6 +49,7 @@ export const FINDING_SENSITIVITY_ORDER: readonly FindingType[] = [
   "address",
   "postal_code",
   "email",
+  "date_of_birth",
 ];
 
 // Public webmail and ISP domains. Mail from one of these is a person writing,

--- a/analysis/src/detect/date-of-birth.ts
+++ b/analysis/src/detect/date-of-birth.ts
@@ -33,8 +33,8 @@ interface DateCandidate {
   day: number;
 }
 
-const NUMERIC_DATE_START = "(?<![\\p{L}\\d])(?<!\\d[^\\p{L}\\d])";
-const NUMERIC_DATE_END = "(?![\\p{L}\\d])(?![^\\p{L}\\d]\\d)";
+const NUMERIC_DATE_START = "(?<![\\p{L}\\d])(?<!\\d[-/.])";
+const NUMERIC_DATE_END = "(?![\\p{L}\\d])(?![-/.]\\d)";
 const ISO_DATE = new RegExp(
   `${NUMERIC_DATE_START}(\\d{4})([-/.])(\\d{1,2})\\2(\\d{1,2})${NUMERIC_DATE_END}`,
   "gu",

--- a/analysis/src/detect/date-of-birth.ts
+++ b/analysis/src/detect/date-of-birth.ts
@@ -111,9 +111,14 @@ function candidatesIn(text: string): DateCandidate[] {
 }
 
 export function normalizeDateOfBirth(raw: string): string | undefined {
-  const candidates = candidatesIn(raw.trim());
-  const exact = candidates.find((candidate) => candidate.start === 0 && candidate.end === raw.trim().length);
-  return exact ? canonicalDate(exact.year, exact.month, exact.day) : undefined;
+  const trimmed = raw.trim();
+  const candidates = candidatesIn(trimmed);
+  for (const candidate of candidates) {
+    if (candidate.start !== 0 || candidate.end !== trimmed.length) continue;
+    const normalized = canonicalDate(candidate.year, candidate.month, candidate.day);
+    if (normalized !== undefined) return normalized;
+  }
+  return undefined;
 }
 
 export function findDateOfBirth(

--- a/analysis/src/detect/date-of-birth.ts
+++ b/analysis/src/detect/date-of-birth.ts
@@ -33,8 +33,16 @@ interface DateCandidate {
   day: number;
 }
 
-const ISO_DATE = /(?<![\p{L}\d])(\d{4})([-/.])(\d{1,2})\2(\d{1,2})(?![\p{L}\d])/gu;
-const DAY_MONTH_YEAR = /(?<![\p{L}\d])(\d{1,2})([-/.])(\d{1,2})\2(\d{4})(?![\p{L}\d])/gu;
+const NUMERIC_DATE_START = "(?<![\\p{L}\\d])(?<!\\d[^\\p{L}\\d])";
+const NUMERIC_DATE_END = "(?![\\p{L}\\d])(?![^\\p{L}\\d]\\d)";
+const ISO_DATE = new RegExp(
+  `${NUMERIC_DATE_START}(\\d{4})([-/.])(\\d{1,2})\\2(\\d{1,2})${NUMERIC_DATE_END}`,
+  "gu",
+);
+const DAY_MONTH_YEAR = new RegExp(
+  `${NUMERIC_DATE_START}(\\d{1,2})([-/.])(\\d{1,2})\\2(\\d{4})${NUMERIC_DATE_END}`,
+  "gu",
+);
 const ENGLISH_DATE = /(?<![\p{L}\d])(?:(\d{1,2})[ \t]+(January|February|March|April|May|June|July|August|September|Sept|Sep|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Oct|Nov|Dec)[ \t]+(\d{4})|(January|February|March|April|May|June|July|August|September|Sept|Sep|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Oct|Nov|Dec)[ \t]+(\d{1,2})(?:,)?[ \t]+(\d{4}))(?![\p{L}\d])/giu;
 
 function canonicalDate(year: number, month: number, day: number): string | undefined {

--- a/analysis/src/detect/date-of-birth.ts
+++ b/analysis/src/detect/date-of-birth.ts
@@ -1,0 +1,124 @@
+const MONTHS: Record<string, number> = {
+  january: 1,
+  jan: 1,
+  february: 2,
+  feb: 2,
+  march: 3,
+  mar: 3,
+  april: 4,
+  apr: 4,
+  may: 5,
+  june: 6,
+  jun: 6,
+  july: 7,
+  jul: 7,
+  august: 8,
+  aug: 8,
+  september: 9,
+  sep: 9,
+  sept: 9,
+  october: 10,
+  oct: 10,
+  november: 11,
+  nov: 11,
+  december: 12,
+  dec: 12,
+};
+
+interface DateCandidate {
+  start: number;
+  end: number;
+  year: number;
+  month: number;
+  day: number;
+}
+
+const ISO_DATE = /(?<![\p{L}\d])(\d{4})([-/.])(\d{1,2})\2(\d{1,2})(?![\p{L}\d])/gu;
+const DAY_MONTH_YEAR = /(?<![\p{L}\d])(\d{1,2})([-/.])(\d{1,2})\2(\d{4})(?![\p{L}\d])/gu;
+const ENGLISH_DATE = /(?<![\p{L}\d])(?:(\d{1,2})[ \t]+(January|February|March|April|May|June|July|August|September|Sept|Sep|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Oct|Nov|Dec)[ \t]+(\d{4})|(January|February|March|April|May|June|July|August|September|Sept|Sep|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Oct|Nov|Dec)[ \t]+(\d{1,2})(?:,)?[ \t]+(\d{4}))(?![\p{L}\d])/giu;
+
+function canonicalDate(year: number, month: number, day: number): string | undefined {
+  if (year < 1000 || year > 9999 || month < 1 || month > 12 || day < 1 || day > 31) {
+    return undefined;
+  }
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+  return `${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+}
+
+function numericCandidates(match: RegExpExecArray): DateCandidate[] {
+  const [raw, first, separator, second, fourth] = match;
+  if (!raw) return [];
+  if (separator && first && second && fourth) {
+    const firstNumber = Number(first);
+    const secondNumber = Number(second);
+    const fourthNumber = Number(fourth);
+    const base = {
+      start: match.index,
+      end: match.index + raw.length,
+    };
+    if (first.length === 4) {
+      return [{ ...base, year: firstNumber, month: secondNumber, day: fourthNumber }];
+    }
+    return [
+      { ...base, year: fourthNumber, month: secondNumber, day: firstNumber },
+      { ...base, year: fourthNumber, month: firstNumber, day: secondNumber },
+    ];
+  }
+  return [];
+}
+
+function englishCandidate(match: RegExpExecArray): DateCandidate | undefined {
+  const [raw, dayFirstDay, dayFirstMonth, dayFirstYear, monthFirstMonth, monthFirstDay, monthFirstYear] = match;
+  if (!raw) return undefined;
+  const day = Number(dayFirstDay ?? monthFirstDay);
+  const monthName = (dayFirstMonth ?? monthFirstMonth)?.toLowerCase();
+  const year = Number(dayFirstYear ?? monthFirstYear);
+  const month = monthName ? MONTHS[monthName] : undefined;
+  if (!month) return undefined;
+  return {
+    start: match.index,
+    end: match.index + raw.length,
+    year,
+    month,
+    day,
+  };
+}
+
+function candidatesIn(text: string): DateCandidate[] {
+  const candidates: DateCandidate[] = [];
+  for (const match of text.matchAll(ISO_DATE)) candidates.push(...numericCandidates(match));
+  for (const match of text.matchAll(DAY_MONTH_YEAR)) candidates.push(...numericCandidates(match));
+  for (const match of text.matchAll(ENGLISH_DATE)) {
+    const candidate = englishCandidate(match);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates.sort((a, b) => a.start - b.start);
+}
+
+export function normalizeDateOfBirth(raw: string): string | undefined {
+  const candidates = candidatesIn(raw.trim());
+  const exact = candidates.find((candidate) => candidate.start === 0 && candidate.end === raw.trim().length);
+  return exact ? canonicalDate(exact.year, exact.month, exact.day) : undefined;
+}
+
+export function findDateOfBirth(
+  text: string,
+  expected: string,
+): { start: number; end: number } | undefined {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(expected) || normalizeDateOfBirth(expected) !== expected) {
+    return undefined;
+  }
+  for (const candidate of candidatesIn(text)) {
+    if (canonicalDate(candidate.year, candidate.month, candidate.day) === expected) {
+      return { start: candidate.start, end: candidate.end };
+    }
+  }
+  return undefined;
+}

--- a/analysis/src/detect/known-values.ts
+++ b/analysis/src/detect/known-values.ts
@@ -1,4 +1,5 @@
 import type { Finding, KnownPiiValue } from "../types";
+import { findDateOfBirth } from "./date-of-birth";
 import { canOmitPostalCodeSeparator } from "./postal-code";
 
 const ADDRESS_BOUNDARY = "\\p{L}\\p{N}";
@@ -107,6 +108,7 @@ interface CompiledKnownValue {
   value: KnownPiiValue;
   pattern?: RegExp;
   structuredAddress?: CompiledStructuredAddress;
+  dateOfBirth?: boolean;
 }
 
 const compiledValues = new WeakMap<
@@ -256,11 +258,13 @@ function compileKnownValues(
         ? compileStructuredAddress(value)
         : undefined;
     const pattern = structuredAddress ? undefined : patternFor(value);
-    if (pattern || structuredAddress) {
+    const dateOfBirth = value.type === "date_of_birth";
+    if (pattern || structuredAddress || dateOfBirth) {
       compiled.push({
         value,
         ...(pattern ? { pattern } : {}),
         ...(structuredAddress ? { structuredAddress } : {}),
+        ...(dateOfBirth ? { dateOfBirth } : {}),
       });
     }
   }
@@ -325,17 +329,25 @@ export function detectKnownValues(
     value,
     pattern,
     structuredAddress,
+    dateOfBirth,
   } of compileKnownValues(values)) {
     const exact = pattern?.exec(text);
     const match = structuredAddress
       ? findStructuredAddress(text, structuredAddress)
-      : exact
-        ? {
-            start: exact.index,
-            end: exact.index + exact[0].length,
-            signal: "known-value.exact" as const,
-          }
-        : undefined;
+      : dateOfBirth
+        ? (() => {
+            const date = findDateOfBirth(text, value.valueNormalized);
+            return date
+              ? { ...date, signal: "known-value.exact" as const }
+              : undefined;
+          })()
+        : exact
+          ? {
+              start: exact.index,
+              end: exact.index + exact[0].length,
+              signal: "known-value.exact" as const,
+            }
+          : undefined;
     if (!match) continue;
 
     findings.push({

--- a/analysis/src/detect/known-values.ts
+++ b/analysis/src/detect/known-values.ts
@@ -96,6 +96,8 @@ function patternFor(value: KnownPiiValue): RegExp | undefined {
         "iu",
       );
     }
+    case "date_of_birth":
+      return undefined;
   }
 }
 

--- a/analysis/src/index.ts
+++ b/analysis/src/index.ts
@@ -55,7 +55,7 @@ export { PERSONAL_DOMAINS } from "./contracts";
 // classification is deliberately outside the contract: type is not versioned
 // per row, so a classifier change reaches stored rows through a release
 // migration instead of through this constant. (See README → Contract.)
-export const ENGINE_VERSION = "0.1.1";
+export const ENGINE_VERSION = "0.1.2";
 
 // AnalyzeOptions.locale ("NL", "nl", "nl-NL") -> ISO 3166-1 alpha-2 region
 function regionFromLocale(locale?: string): string | undefined {

--- a/analysis/src/profile-values.ts
+++ b/analysis/src/profile-values.ts
@@ -6,6 +6,7 @@ import {
   normalizeCardNumber,
 } from "./detect/credit-card";
 import { detectEmails } from "./detect/email";
+import { normalizeDateOfBirth } from "./detect/date-of-birth";
 import { isValidIban, normalizeIban } from "./detect/iban";
 import {
   detectPostalCodes,
@@ -70,6 +71,8 @@ export function normalizeValue(type: FindingType, raw: string): string {
       return normalizeIban(raw.trim());
     case "credit_card":
       return normalizeCreditCard(raw);
+    case "date_of_birth":
+      return normalizeDateOfBirth(raw) ?? "";
   }
 }
 
@@ -96,5 +99,7 @@ export function validateValue(type: FindingType, raw: string): boolean {
         /^\*{4}\d{4}$/.test(normalized)
         || (/^[\d -]+$/.test(raw) && isValidCardNumber(normalized))
       );
+    case "date_of_birth":
+      return normalizeDateOfBirth(raw) !== undefined;
   }
 }

--- a/analysis/test/known-values.test.ts
+++ b/analysis/test/known-values.test.ts
@@ -114,6 +114,22 @@ describe("known PII values", () => {
     );
   });
 
+  it.each([
+    "DOB 1 1985-04-09",
+    "DOB 1985-04-09 10:30",
+  ])("accepts a numeric date near whitespace-separated numbers: %s", async (text) => {
+    const result = await analyzeText(text, {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        type: "date_of_birth",
+        valueNormalized: "1985-04-09",
+      }),
+    );
+  });
+
   it("does not emit unrelated dates as a date of birth", async () => {
     const result = await analyzeText("Invoice date: 2020-04-09", {
       knownValues: [known("date_of_birth", "1985-04-09")],

--- a/analysis/test/known-values.test.ts
+++ b/analysis/test/known-values.test.ts
@@ -89,6 +89,31 @@ describe("known PII values", () => {
     );
   });
 
+  it.each([
+    "1985-04-09-10",
+    "1985-04-09.123",
+    "10-1985-04-09",
+  ])("rejects a numeric date embedded in a larger token: %s", async (text) => {
+    const result = await analyzeText(`Reference: ${text}`, {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("keeps ordinary sentence punctuation after a numeric date valid", async () => {
+    const result = await analyzeText("Sentence 1985-04-09.", {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        type: "date_of_birth",
+        valueNormalized: "1985-04-09",
+      }),
+    );
+  });
+
   it("does not emit unrelated dates as a date of birth", async () => {
     const result = await analyzeText("Invoice date: 2020-04-09", {
       knownValues: [known("date_of_birth", "1985-04-09")],

--- a/analysis/test/known-values.test.ts
+++ b/analysis/test/known-values.test.ts
@@ -67,6 +67,24 @@ describe("known PII values", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it.each(["09-04-1985", "09.04.1985"])(
+    "prefers a known DOB over an overlapping Dutch phone: %s",
+    async (text) => {
+      const result = await analyzeText(`DOB: ${text}`, {
+        locale: "NL",
+        knownValues: [known("date_of_birth", "1985-04-09")],
+      });
+
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0]).toEqual(
+        expect.objectContaining({
+          type: "date_of_birth",
+          valueNormalized: "1985-04-09",
+        }),
+      );
+    },
+  );
+
   it.each([
     "1985-04-09",
     "09-04-1985",

--- a/analysis/test/known-values.test.ts
+++ b/analysis/test/known-values.test.ts
@@ -43,6 +43,95 @@ describe("known PII values", () => {
     ]);
   });
 
+  it("matches a known date of birth and returns its canonical value", async () => {
+    const result = await analyzeText("Birth date: 1985-04-09", {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        type: "date_of_birth",
+        valueRaw: "1985-04-09",
+        valueNormalized: "1985-04-09",
+        confidence: "pattern",
+        signals: [{ id: "known-value.exact" }],
+      }),
+    ]);
+  });
+
+  it("does not emit dates of birth without a known profile value", async () => {
+    const result = await analyzeText(
+      "The appointment was on 9 April 1985 and moved on 2020/04/09.",
+    );
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it.each([
+    "1985-04-09",
+    "09-04-1985",
+    "04/09/1985",
+    "9.4.1985",
+    "9 April 1985",
+    "April 9, 1985",
+    "9 Apr 1985",
+    "Apr 9 1985",
+  ])("matches supported date-of-birth spelling: %s", async (text) => {
+    const result = await analyzeText(`Date of birth: ${text}`, {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        type: "date_of_birth",
+        valueNormalized: "1985-04-09",
+      }),
+    );
+  });
+
+  it("does not emit unrelated dates as a date of birth", async () => {
+    const result = await analyzeText("Invoice date: 2020-04-09", {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("accepts either interpretation of an ambiguous numeric date", async () => {
+    const monthFirst = await analyzeText("DOB: 04/09/1985", {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+    const dayFirst = await analyzeText("DOB: 04/09/1985", {
+      knownValues: [known("date_of_birth", "1985-09-04")],
+    });
+
+    expect(monthFirst.findings[0]?.valueNormalized).toBe("1985-04-09");
+    expect(dayFirst.findings[0]?.valueNormalized).toBe("1985-09-04");
+  });
+
+  it.each([
+    "1985-02-29",
+    "31/04/1985",
+    "April 31, 1985",
+    "April 9",
+    "1985-04",
+    "9 Apr",
+  ])("rejects invalid or partial date candidate: %s", async (text) => {
+    const result = await analyzeText(`Value: ${text}`, {
+      knownValues: [known("date_of_birth", "1985-04-09")],
+    });
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("does not scan dates for an incomplete known profile value", async () => {
+    const result = await analyzeText("DOB: 9 April 1985", {
+      knownValues: [known("date_of_birth", "9 April 1985")],
+    });
+
+    expect(result.findings).toEqual([]);
+  });
+
   it("finds an exact IBAN with normalized spacing", async () => {
     const result = await analyzeText("Account: NL91  ABNA 0417.1643 00", {
       knownValues: [known("iban", "NL91ABNA0417164300")],

--- a/analysis/test/profile-values.test.ts
+++ b/analysis/test/profile-values.test.ts
@@ -81,4 +81,9 @@ describe("profile values", () => {
     expect(validateValue("date_of_birth", "1985-04-09")).toBe(true);
     expect(validateValue("date_of_birth", "1985-02-29")).toBe(false);
   });
+
+  it("uses the first valid interpretation of an ambiguous whole-string date", () => {
+    expect(normalizeValue("date_of_birth", "04/13/1985")).toBe("1985-04-13");
+    expect(validateValue("date_of_birth", "04/13/1985")).toBe(true);
+  });
 });

--- a/analysis/test/profile-values.test.ts
+++ b/analysis/test/profile-values.test.ts
@@ -75,4 +75,10 @@ describe("profile values", () => {
     expect(validateValue("postal_code", "1234ab")).toBe(true);
     expect(validateValue("postal_code", "not a postcode")).toBe(false);
   });
+
+  it("normalizes and validates complete dates of birth", () => {
+    expect(normalizeValue("date_of_birth", "9 April 1985")).toBe("1985-04-09");
+    expect(validateValue("date_of_birth", "1985-04-09")).toBe(true);
+    expect(validateValue("date_of_birth", "1985-02-29")).toBe(false);
+  });
 });

--- a/src/main/globalDb.test.ts
+++ b/src/main/globalDb.test.ts
@@ -223,6 +223,104 @@ describe("global.db", () => {
     ]);
   });
 
+  it("exposes a complete profile birth date as one canonical match value", () => {
+    const target = getGlobalDb();
+    target
+      .prepare(
+        `UPDATE profile
+         SET birth_year = 1985, birth_month = 4, birth_day = 9
+         WHERE id = 1`,
+      )
+      .run();
+
+    expect(
+      target
+        .prepare(
+          `SELECT type, value_normalized
+           FROM profile_match_values
+           WHERE type = 'date_of_birth'`,
+        )
+        .all(),
+    ).toEqual([{
+      type: "date_of_birth",
+      value_normalized: "1985-04-09",
+    }]);
+  });
+
+  it.each([
+    ["absent", null, null, null],
+    ["missing day", 1985, 4, null],
+    ["missing month", 1985, null, 9],
+    ["missing year", null, 4, 9],
+  ])("omits an %s profile birth date", (_label, year, month, day) => {
+    const target = getGlobalDb();
+    target
+      .prepare(
+        `UPDATE profile
+         SET birth_year = ?, birth_month = ?, birth_day = ?
+         WHERE id = 1`,
+      )
+      .run(year, month, day);
+
+    expect(
+      target
+        .prepare(
+          `SELECT type, value_normalized
+           FROM profile_match_values
+           WHERE type = 'date_of_birth'`,
+        )
+        .all(),
+    ).toEqual([]);
+  });
+
+  it("recreates an old match view without losing profile or suppression data", () => {
+    const path = join(userDataDir, "global.db");
+    const legacy = new Database(path);
+    legacy.exec(`
+      CREATE TABLE profile (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        birth_year INTEGER,
+        birth_month INTEGER,
+        birth_day INTEGER,
+        country TEXT
+      );
+      CREATE TABLE profile_emails (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        address TEXT NOT NULL,
+        value_normalized TEXT NOT NULL UNIQUE
+      );
+      CREATE TABLE pii_suppressions (
+        type TEXT NOT NULL,
+        value_normalized TEXT NOT NULL,
+        PRIMARY KEY (type, value_normalized)
+      );
+      INSERT INTO profile (id, birth_year, birth_month, birth_day)
+        VALUES (1, 1985, 4, 9);
+      INSERT INTO profile_emails (address, value_normalized)
+        VALUES ('Person@Example.com', 'person@example.com');
+      INSERT INTO pii_suppressions (type, value_normalized)
+        VALUES ('email', 'suppressed@example.com');
+      CREATE VIEW profile_match_values AS
+        SELECT 'email' AS type, value_normalized FROM profile_emails;
+    `);
+    legacy.close();
+
+    const target = getGlobalDb();
+
+    expect(target.prepare("SELECT birth_year FROM profile WHERE id = 1").pluck().get())
+      .toBe(1985);
+    expect(target.prepare("SELECT COUNT(*) FROM pii_suppressions").pluck().get())
+      .toBe(1);
+    expect(target.prepare(
+      `SELECT type, value_normalized
+       FROM profile_match_values
+       ORDER BY type, value_normalized`,
+    ).all()).toEqual([
+      { type: "date_of_birth", value_normalized: "1985-04-09" },
+      { type: "email", value_normalized: "person@example.com" },
+    ]);
+  });
+
   it("keeps only consumed columns in the global profile schema", () => {
     const target = getGlobalDb();
     const columns = (name: string) => (

--- a/src/main/globalDb.ts
+++ b/src/main/globalDb.ts
@@ -119,7 +119,22 @@ function globalSchemaSql(schema: "main" | "global"): string {
       PRIMARY KEY (type, value_normalized)
     );
 
-    CREATE VIEW IF NOT EXISTS ${schema}.profile_match_values AS
+    INSERT INTO ${schema}.profile (id)
+      VALUES (1)
+      ON CONFLICT(id) DO NOTHING;
+  `;
+}
+
+function recreateProfileMatchValuesView(
+  target: Database.Database,
+  schema: "main" | "global",
+): void {
+  // View-only replacement is deliberately non-destructive: reverting the code
+  // can recreate the prior definition while stored profile data remains intact.
+  target.exec(`
+    DROP VIEW IF EXISTS ${schema}.profile_match_values;
+
+    CREATE VIEW ${schema}.profile_match_values AS
       SELECT 'email' AS type, value_normalized
         FROM profile_emails
       UNION ALL
@@ -138,16 +153,19 @@ function globalSchemaSql(schema: "main" | "global"): string {
         FROM profile_national_ids
       UNION ALL
       SELECT type, value_normalized
-        FROM profile_payments;
-
-    INSERT INTO ${schema}.profile (id)
-      VALUES (1)
-      ON CONFLICT(id) DO NOTHING;
-  `;
+        FROM profile_payments
+      UNION ALL
+      SELECT 'date_of_birth', printf('%04d-%02d-%02d', birth_year, birth_month, birth_day)
+        FROM profile
+       WHERE birth_year IS NOT NULL
+         AND birth_month IS NOT NULL
+         AND birth_day IS NOT NULL;
+  `);
 }
 
 function initGlobalSchema(target: Database.Database, schema: "main" | "global"): void {
   target.exec(globalSchemaSql(schema));
+  recreateProfileMatchValuesView(target, schema);
 }
 
 function migrateLegacySettings(target: Database.Database, globalPath: string): void {

--- a/src/main/globalDb.ts
+++ b/src/main/globalDb.ts
@@ -131,36 +131,39 @@ function recreateProfileMatchValuesView(
 ): void {
   // View-only replacement is deliberately non-destructive: reverting the code
   // can recreate the prior definition while stored profile data remains intact.
-  target.exec(`
-    DROP VIEW IF EXISTS ${schema}.profile_match_values;
+  const replace = target.transaction(() => {
+    target.exec(`
+      DROP VIEW IF EXISTS ${schema}.profile_match_values;
 
-    CREATE VIEW ${schema}.profile_match_values AS
-      SELECT 'email' AS type, value_normalized
-        FROM profile_emails
-      UNION ALL
-      SELECT 'phone', value_normalized
-        FROM profile_phones
-      UNION ALL
-      SELECT 'address', value_normalized
-        FROM profile_addresses
-       WHERE raw IS NULL OR postal_code_normalized IS NULL
-      UNION ALL
-      SELECT 'postal_code', postal_code_normalized
-        FROM profile_addresses
-       WHERE postal_code_normalized IS NOT NULL
-      UNION ALL
-      SELECT 'national_id', value_normalized
-        FROM profile_national_ids
-      UNION ALL
-      SELECT type, value_normalized
-        FROM profile_payments
-      UNION ALL
-      SELECT 'date_of_birth', printf('%04d-%02d-%02d', birth_year, birth_month, birth_day)
-        FROM profile
-       WHERE birth_year IS NOT NULL
-         AND birth_month IS NOT NULL
-         AND birth_day IS NOT NULL;
-  `);
+      CREATE VIEW ${schema}.profile_match_values AS
+        SELECT 'email' AS type, value_normalized
+          FROM profile_emails
+        UNION ALL
+        SELECT 'phone', value_normalized
+          FROM profile_phones
+        UNION ALL
+        SELECT 'address', value_normalized
+          FROM profile_addresses
+         WHERE raw IS NULL OR postal_code_normalized IS NULL
+        UNION ALL
+        SELECT 'postal_code', postal_code_normalized
+          FROM profile_addresses
+         WHERE postal_code_normalized IS NOT NULL
+        UNION ALL
+        SELECT 'national_id', value_normalized
+          FROM profile_national_ids
+        UNION ALL
+        SELECT type, value_normalized
+          FROM profile_payments
+        UNION ALL
+        SELECT 'date_of_birth', printf('%04d-%02d-%02d', birth_year, birth_month, birth_day)
+          FROM profile
+         WHERE birth_year IS NOT NULL
+           AND birth_month IS NOT NULL
+           AND birth_day IS NOT NULL;
+    `);
+  });
+  replace();
 }
 
 function initGlobalSchema(target: Database.Database, schema: "main" | "global"): void {

--- a/src/main/services/analysis.test.ts
+++ b/src/main/services/analysis.test.ts
@@ -54,6 +54,7 @@ import { getDb, initDb } from "../db";
 import {
   invalidateAllAnalysisPasses,
   invalidateAnalysisPass,
+  getKnownPiiValues,
   needsAnalysisPass,
   persistFindings,
   runAnalysisPass,
@@ -152,9 +153,18 @@ beforeAll(() => {
   `);
 });
 beforeEach(() => {
-  getDb().exec(
-    "DELETE FROM pii_findings; DELETE FROM messages; DELETE FROM vendors; DELETE FROM settings; DELETE FROM companies.companies; DELETE FROM global.profile_phones; DELETE FROM global.profile_addresses; DELETE FROM global.pii_suppressions;",
-  );
+  getDb().exec(`
+    DELETE FROM pii_findings;
+    DELETE FROM messages;
+    DELETE FROM vendors;
+    DELETE FROM settings;
+    DELETE FROM companies.companies;
+    DELETE FROM global.profile_phones;
+    DELETE FROM global.profile_addresses;
+    DELETE FROM global.pii_suppressions;
+    UPDATE global.profile
+    SET birth_year = NULL, birth_month = NULL, birth_day = NULL;
+  `);
   mockAnalyze.mockReset();
   mockAnalyzeMessage.mockReset();
   mockExtractAddress.mockReset();
@@ -163,6 +173,23 @@ beforeEach(() => {
   mockIsSenderContact.mockReset();
   mockIsSenderContact.mockReturnValue(false);
   mockListAccounts.mockReturnValue([]);
+});
+
+describe("getKnownPiiValues", () => {
+  it("returns a complete profile birth date from the canonical view", () => {
+    getDb()
+      .prepare(
+        `UPDATE global.profile
+         SET birth_year = 1985, birth_month = 4, birth_day = 9
+         WHERE id = 1`,
+      )
+      .run();
+
+    expect(getKnownPiiValues()).toContainEqual({
+      type: "date_of_birth",
+      valueNormalized: "1985-04-09",
+    });
+  });
 });
 
 describe("runAnalysisPass", () => {

--- a/src/main/services/pii.test.ts
+++ b/src/main/services/pii.test.ts
@@ -101,6 +101,17 @@ function insertProfileMatch(type: PiiType, value: string): void {
          VALUES (?, ?)`,
       ).run(type, value);
       break;
+    case "date_of_birth": {
+      const [year, month, day] = value.split("-").map(Number);
+      target
+        .prepare(
+          `UPDATE global.profile
+           SET birth_year = ?, birth_month = ?, birth_day = ?
+           WHERE id = 1`,
+        )
+        .run(year, month, day);
+      break;
+    }
   }
 }
 
@@ -113,7 +124,7 @@ beforeEach(() => {
      DELETE FROM global.profile_addresses;
      DELETE FROM global.profile_national_ids;
      DELETE FROM global.profile_payments;
-     UPDATE global.profile SET country = NULL WHERE id = 1;
+     UPDATE global.profile SET birth_year = NULL, birth_month = NULL, birth_day = NULL, country = NULL WHERE id = 1;
      DELETE FROM pii_findings;
      DELETE FROM messages;
      DELETE FROM vendors;`,
@@ -129,6 +140,7 @@ describe("maskValue", () => {
     expect(maskValue("national_id", "123456789")).toBe("•••• 789");
     expect(maskValue("postal_code", "1012AB")).toBe("10•••");
     expect(maskValue("address", "reigerskamp 611")).toBe("rei•••");
+    expect(maskValue("date_of_birth", "1985-04-09")).toBe("••-••-1985");
   });
 });
 
@@ -204,6 +216,21 @@ describe("profile matches", () => {
     insertFinding("m1", "phone", "+31612345678");
 
     expect(getVendorPiiSummary(vid).values[0].isMatch).toBe(true);
+  });
+
+  it("labels a matching date of birth and masks its day and month", () => {
+    insertProfileMatch("date_of_birth", "1985-04-09");
+    const vid = insertVendor();
+    insertMsg("m1", vid, 100);
+    insertFinding("m1", "date_of_birth", "1985-04-09");
+
+    expect(getVendorPiiSummary(vid).values[0]).toEqual(
+      expect.objectContaining({
+        type: "date_of_birth",
+        maskedValue: "••-••-1985",
+        isMatch: true,
+      }),
+    );
   });
 
   it("leaves a value outside the profile unlabelled", () => {

--- a/src/main/services/pii.test.ts
+++ b/src/main/services/pii.test.ts
@@ -233,6 +233,45 @@ describe("profile matches", () => {
     );
   });
 
+  it.each([
+    ["changed", 1990, 5, 10],
+    ["removed", null, null, null],
+  ])("hides a stale date-of-birth finding after the profile date is %s", (
+    _action,
+    year,
+    month,
+    day,
+  ) => {
+    insertProfileMatch("date_of_birth", "1985-04-09");
+    const vid = insertVendor();
+    insertMsg("m1", vid, 100);
+    const ref = insertFinding("m1", "date_of_birth", "1985-04-09");
+
+    expect(getVendorPiiSummary(vid).values).toEqual([
+      expect.objectContaining({
+        ref,
+        type: "date_of_birth",
+        maskedValue: "••-••-1985",
+        isMatch: true,
+      }),
+    ]);
+    expect(revealVendorPiiValues(vid)).toEqual([{ ref, value: "1985-04-09" }]);
+
+    getDb()
+      .prepare(
+        `UPDATE global.profile
+         SET birth_year = ?, birth_month = ?, birth_day = ?
+         WHERE id = 1`,
+      )
+      .run(year, month, day);
+
+    expect(getVendorPiiSummary(vid).values).toEqual([]);
+    expect(getPiiOverview().values).toEqual([]);
+    expect(revealVendorPiiValues(vid)).toEqual([]);
+    expect(revealPiiValues()).toEqual([]);
+    expect(getPiiValueCompanies(ref)).toEqual([]);
+  });
+
   it("leaves a value outside the profile unlabelled", () => {
     insertProfileMatch("email", "user@example.com");
     const vid = insertVendor();

--- a/src/main/services/pii.ts
+++ b/src/main/services/pii.ts
@@ -153,6 +153,10 @@ const visibleFindingSql = (
   suppression: SuppressionScope = "excluded",
 ): string => {
   const match = profileMatchSql(findingAlias);
+  const typeAllowed = `(
+    ${findingAlias}.type != 'date_of_birth'
+    OR ${match}
+  )`;
   const inferred = `
     ${findingAlias}.in_quoted_text = 0
     AND ${findingAlias}.in_footer = 0
@@ -162,8 +166,8 @@ const visibleFindingSql = (
       AND ${seenInCompanyFooterSql(findingAlias, vendorAlias)}
     )`;
 
-  if (suppression === "either") return `(${match} OR (${inferred}))`;
-  return `(${match} OR (${inferred}${suppressionSql(findingAlias, suppression)}))`;
+  if (suppression === "either") return `(${typeAllowed} AND (${match} OR (${inferred})))`;
+  return `(${typeAllowed} AND (${match} OR (${inferred}${suppressionSql(findingAlias, suppression)})))`;
 };
 
 // One indexed lookup by (type, value_normalized), counting company identities

--- a/src/main/services/pii.ts
+++ b/src/main/services/pii.ts
@@ -39,6 +39,8 @@ export function maskValue(type: PiiType, normalized: string): string {
       return `${v.slice(0, 2)}•••`;
     case "address":
       return `${v.slice(0, 3)}•••`;
+    case "date_of_birth":
+      return `••-••-${v.slice(0, 4)}`;
     default:
       return "•••";
   }

--- a/src/main/services/profile.test.ts
+++ b/src/main/services/profile.test.ts
@@ -439,4 +439,22 @@ describe("profile service", () => {
       }],
     }))).toBe(false);
   });
+
+  it("reports adding, changing, and removing a birth date as analysis changes", () => {
+    expect(seedProfileEmailsFromAccounts()).toBe(1);
+    const withoutBirthDate = emptyProfile();
+    const firstBirthDate = emptyProfile({
+      birthDate: { day: 9, month: 4, year: 1985 },
+    });
+    const changedBirthDate = emptyProfile({
+      birthDate: { day: 10, month: 4, year: 1985 },
+    });
+
+    expect(saveUserProfile(withoutBirthDate)).toBe(false);
+    expect(saveUserProfile(firstBirthDate)).toBe(true);
+    expect(saveUserProfile(firstBirthDate)).toBe(false);
+    expect(saveUserProfile(changedBirthDate)).toBe(true);
+    expect(saveUserProfile(withoutBirthDate)).toBe(true);
+    expect(saveUserProfile(withoutBirthDate)).toBe(false);
+  });
 });

--- a/src/renderer/utils/piiLabels.ts
+++ b/src/renderer/utils/piiLabels.ts
@@ -16,4 +16,5 @@ export const PII_LABELS: Record<PiiType, string> = {
   address: "Address",
   postal_code: "Postal",
   email: "Email",
+  date_of_birth: "Date of birth",
 };

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -9,6 +9,7 @@
     "analysis/src/types.ts",
     "analysis/src/detect/address.ts",
     "analysis/src/detect/credit-card.ts",
+    "analysis/src/detect/date-of-birth.ts",
     "analysis/src/detect/email.ts",
     "analysis/src/detect/iban.ts",
     "analysis/src/detect/postal-code.ts",


### PR DESCRIPTION
Closes #56

## Summary
- Make the existing profile Date of Birth participate in personal-data analysis.
- Match only complete date candidates that normalize exactly to the complete profile DOB.
- Show matched DOB findings as `Date of birth`, masked as `••-••-YYYY`, with the normal reveal control.

## Matching contract
- Profile-gated only; no complete profile DOB means no date scan or finding.
- Canonical value: `YYYY-MM-DD`.
- Supports ISO and common numeric separators, ambiguous day/month ordering, and English full/abbreviated month names.
- Requires a four-digit year and a real calendar date.
- Rejects unrelated dates, partial dates, ages, and dates embedded in larger numeric tokens.
- Uses direct parsing with no new dependency.

## Persistence and reanalysis
- Adds the complete DOB to the canonical `profile_match_values` view.
- Recreates that view transactionally so existing profile and suppression data is preserved.
- Adding, changing, or removing DOB uses the existing analysis invalidation path.
- Stale DOB findings remain hidden unless they match the current profile DOB.
- Bumps the analysis engine version to `0.1.2` so existing messages are reanalysed.

## Classification
DOB is handled as a data class, not assigned a new high-sensitivity score. Exact profile equality uses the existing high ownership-confidence signal.

## Verification
- Analysis: 302 tests passed; typecheck and build passed.
- Main: 276 tests passed under Node 22.
- Root node and web typechecks passed.
- Production main, preload, and renderer build passed.
- `git diff --check` passed.
- Independent spec and architecture/code-quality reviews passed after remediation.

## Migration and rollback
The migration only replaces a view definition inside a transaction. It does not move or delete stored profile or suppression data. Reverting recreates the prior view definition on the next database initialization.

## Out of scope
- Generic date detection
- Partial dates, ages, or inferred birthdays
- New sensitivity scoring
- A second DOB editor through the generic `It's mine` action
